### PR TITLE
Fix typo in Tensor Utilities docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@
    tensor/tensor.rst
 
    Tensor Operations <tensor/operations/index.rst>
-   Tensor Utilites <tensor/utilities/index.rst>
+   Tensor Utilities <tensor/utilities/index.rst>
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/tensor/utilities/index.rst
+++ b/docs/source/tensor/utilities/index.rst
@@ -1,5 +1,5 @@
-Tensor Utilites
-===============
+Tensor Utilities
+================
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Summary
- correct spelling mistake in documentation to `Tensor Utilities`

## Testing
- `pytest -q`
- `make -C docs html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842be515a8c832e8f26e1a55a6f80a8