### PR TITLE
Add int input support for histogramdd

### DIFF
--- a/docs/source/tensor/utilities/histogramdd.rst
+++ b/docs/source/tensor/utilities/histogramdd.rst
@@ -11,7 +11,7 @@ Function Signature
     def histogramdd(
         a: Tensor,
         /,
-        bins: list[int],
+        bins: int | list[int],
         range: list[tuple[float, float]],
         density: bool = False,
     ) -> tuple[Tensor, Tensor]
@@ -21,8 +21,9 @@ Parameters
 - **a** (*Tensor*):
   A 2D tensor of shape (N, D) representing N D-dimensional samples.
 
-- **bins** (*list[int]*):
-  Number of bins for each dimension.
+- **bins** (*int | list[int]*):
+  Number of bins for each dimension. If an integer is provided, it will be
+  used for all dimensions.
 
 - **range** (*list[tuple[float, float]]*):
   Lower and upper range of each dimension.
@@ -45,3 +46,4 @@ Example
 
     >>> x = Tensor([[0.5, -0.2], [1.0, 0.3], [-0.8, 0.7]])
     >>> hist, edges = histogramdd(x, bins=[4, 4], range=[(-1, 1), (-1, 1)])
+    >>> hist, edges = histogramdd(x, bins=4, range=[(-1, 1), (-1, 1)])

--- a/lucid/_util/__init__.py
+++ b/lucid/_util/__init__.py
@@ -186,10 +186,12 @@ def topk(
 def histogramdd(
     a: Tensor,
     /,
-    bins: list[int],
+    bins: int | list[int],
     range: list[tuple[float, float]],
     density: bool = False,
 ) -> tuple[Tensor, Tensor]:
+    if isinstance(bins, int):
+        bins = [bins] * a.shape[1]
     return func.histogramdd(bins, range, density)(a)
 
 

--- a/lucid/_util/func.py
+++ b/lucid/_util/func.py
@@ -1080,11 +1080,13 @@ class topk(operation):
 class histogramdd(operation):
     def __init__(
         self,
-        bins: list[int],
+        bins: int | list[int],
         range: list[tuple[float, float]],
         density: bool = False,
     ) -> None:
         super().__init__()
+        if isinstance(bins, int):
+            bins = [bins] * len(range)
         if not all(isinstance(b, int) for b in bins):
             raise TypeError("All elements of bins must be integers.")
 


### PR DESCRIPTION
## Summary
- allow `histogramdd` to take an `int` or list of ints
- document new behavior in the histogramdd rst

## Testing
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6846be1a51d0832ea30fcd37c3681991