### PR TITLE
Add model repr similar to PyTorch

### DIFF
--- a/lucid/nn/module.py
+++ b/lucid/nn/module.py
@@ -161,6 +161,9 @@ class Module:
         for module in self._modules.values():
             yield from module.modules()
 
+    def children(self: nn.Module) -> Iterator[Self]:
+        return iter(self._modules.values())
+
     def count_parameters(self, recurse: bool = True) -> int:
         total_params = sum(p.size for p in self.parameters(recurse=recurse))
         return total_params

--- a/lucid/nn/modules/attention.py
+++ b/lucid/nn/modules/attention.py
@@ -9,6 +9,11 @@ from lucid.types import _Scalar
 __all__ = ["ScaledDotProductAttention", "MultiHeadAttention"]
 
 
+@nn.auto_repr(
+    "dropout_p",
+    "is_causal",
+    "scale",
+)
 class ScaledDotProductAttention(nn.Module):
     def __init__(
         self,
@@ -35,6 +40,14 @@ class ScaledDotProductAttention(nn.Module):
         )
 
 
+@nn.auto_repr(
+    "embed_dim",
+    "num_heads",
+    "dropout",
+    "bias",
+    "add_bias_kv",
+    "add_zero_attn",
+)
 class MultiHeadAttention(nn.Module):
     def __init__(
         self,

--- a/lucid/nn/modules/attention.py
+++ b/lucid/nn/modules/attention.py
@@ -9,11 +9,7 @@ from lucid.types import _Scalar
 __all__ = ["ScaledDotProductAttention", "MultiHeadAttention"]
 
 
-@nn.auto_repr(
-    "dropout_p",
-    "is_causal",
-    "scale",
-)
+@nn.auto_repr("dropout_p", "is_causal", "scale")
 class ScaledDotProductAttention(nn.Module):
     def __init__(
         self,

--- a/lucid/nn/modules/conv.py
+++ b/lucid/nn/modules/conv.py
@@ -119,6 +119,22 @@ class _ConvNd(nn.Module):
                 bound = 1 / math.sqrt(fan_in)
                 nn.init.uniform(self.bias, -bound, bound)
 
+    def extra_repr(self):
+        s = (
+            f"{self.in_channels}, {self.out_channels}, "
+            f"kernel_size={self.kernel_size}, stride={self.stride}"
+        )
+        if self.padding != (0,) * len(self.padding):
+            s += f", padding={self.padding}"
+        if self.dilation != (1,) * len(self.dilation):
+            s += f", dilation={self.dilation}"
+        if self.groups != 1:
+            s += f", groups={self.groups}"
+        if self.bias is None:
+            s += ", bias=False"
+
+        return s
+
 
 class Conv1d(_ConvNd):
     def __init__(

--- a/lucid/nn/modules/conv.py
+++ b/lucid/nn/modules/conv.py
@@ -119,7 +119,7 @@ class _ConvNd(nn.Module):
                 bound = 1 / math.sqrt(fan_in)
                 nn.init.uniform(self.bias, -bound, bound)
 
-    def extra_repr(self):
+    def extra_repr(self) -> str:
         s = (
             f"{self.in_channels}, {self.out_channels}, "
             f"kernel_size={self.kernel_size}, stride={self.stride}"

--- a/lucid/nn/modules/drop.py
+++ b/lucid/nn/modules/drop.py
@@ -3,8 +3,6 @@ import lucid.nn as nn
 import lucid.nn.functional as F
 
 from lucid._tensor import Tensor
-import lucid.nn.functional
-import lucid.nn.parameter
 
 
 __all__ = [
@@ -56,6 +54,7 @@ class AlphaDropout(_DropoutNd):
         return F.alpha_dropout(input_, self.p, self.training)
 
 
+@nn.auto_repr("block_size", "p")
 class DropBlock(nn.Module):
     def __init__(self, block_size: int, p: float = 0.1, eps: float = 1e-7) -> None:
         super().__init__()

--- a/lucid/nn/modules/einops.py
+++ b/lucid/nn/modules/einops.py
@@ -9,6 +9,7 @@ from lucid.einops._func import _EinopsPattern
 __all__ = ["Rearrange"]
 
 
+@nn.auto_repr("pattern")
 class Rearrange(nn.Module):
     def __init__(self, pattern: _EinopsPattern, **shapes: int) -> None:
         super().__init__()

--- a/lucid/nn/modules/linear.py
+++ b/lucid/nn/modules/linear.py
@@ -46,6 +46,9 @@ class Linear(nn.Module):
     def forward(self, input_: Tensor) -> Tensor:
         return F.linear(input_, self.weight, self.bias)
 
+    def extra_repr(self) -> str:
+        return f"{self.in_features}, {self.out_features}, bias={self.bias is not None}"
+
 
 class Bilinear(nn.Module):
     def __init__(
@@ -76,3 +79,9 @@ class Bilinear(nn.Module):
 
     def forward(self, input_1: Tensor, input_2: Tensor) -> Tensor:
         return F.bilinear(input_1, input_2, self.weight, self.bias)
+
+    def extra_repr(self) -> str:
+        return (
+            f"{self.in1_features}, {self.in2_features}, {self.out_features}, "
+            f"bias={self.bias is not None}"
+        )

--- a/lucid/nn/modules/loss.py
+++ b/lucid/nn/modules/loss.py
@@ -13,6 +13,7 @@ __all__ = ["MSELoss", "BCELoss", "CrossEntropyLoss", "NLLLoss", "HuberLoss"]
 _ReductionType = Literal["mean", "sum"]
 
 
+@nn.auto_repr("reduction")
 class _Loss(nn.Module):
     def __init__(self, reduction: _ReductionType | None = "mean") -> None:
         super().__init__()
@@ -25,6 +26,7 @@ class _Loss(nn.Module):
         NotImplemented
 
 
+@nn.auto_repr("reduction")
 class _WeightedLoss(nn.Module):
     def __init__(
         self, weight: Tensor | None = None, reduction: _ReductionType | None = "mean"
@@ -84,6 +86,7 @@ class NLLLoss(_WeightedLoss):
         return F.nll_loss(input_, target, weight=self.weight, reduction=self.reduction)
 
 
+@nn.auto_repr("reduction", "delta")
 class HuberLoss(_Loss):
     def __init__(
         self, reduction: _ReductionType | None = "mean", delta: float = 1.0

--- a/lucid/nn/modules/norm.py
+++ b/lucid/nn/modules/norm.py
@@ -65,6 +65,12 @@ class _NormBase(nn.Module):
             self.weight = nn.Parameter(lucid.ones_like(self.weight))
             self.bias = nn.Parameter(lucid.zeros_like(self.bias))
 
+    def extra_repr(self) -> str:
+        return (
+            f"{self.num_features}, eps={self.eps}, momentum={self.momentum}, "
+            f"affine={self.affine}, track_running_stats={self.track_running_stats}"
+        )
+
 
 class _BatchNorm(_NormBase):
     def __init__(
@@ -150,6 +156,7 @@ class InstanceNorm3d(_InstanceNorm):
         return super().forward(input_)
 
 
+@nn.auto_repr("normalized_shape", "eps", "elementwise_affine")
 class LayerNorm(nn.Module):
     def __init__(
         self,
@@ -185,6 +192,7 @@ class LayerNorm(nn.Module):
         )
 
 
+@nn.auto_repr("channels", "eps")
 class GlobalResponseNorm(nn.Module):
     def __init__(self, channels: int, eps: float = 1e-6) -> None:
         super().__init__()

--- a/lucid/nn/modules/transformer.py
+++ b/lucid/nn/modules/transformer.py
@@ -17,6 +17,16 @@ __all__ = [
 ]
 
 
+@nn.auto_repr(
+    "d_model",
+    "num_heads",
+    "dim_feedforward",
+    "dropout",
+    "activation",
+    "layer_norm_eps",
+    "norm_first",
+    "bias",
+)
 class TransformerEncoderLayer(nn.Module):
     def __init__(
         self,
@@ -89,6 +99,16 @@ class TransformerEncoderLayer(nn.Module):
         return x
 
 
+@nn.auto_repr(
+    "d_model",
+    "num_heads",
+    "dim_feedforward",
+    "dropout",
+    "activation",
+    "layer_norm_eps",
+    "norm_first",
+    "bias",
+)
 class TransformerDecoderLayer(nn.Module):
     def __init__(
         self,
@@ -228,6 +248,9 @@ class TransformerEncoder(nn.Module):
 
         return output
 
+    def extra_repr(self) -> str:
+        return f"num_layers={self.num_layers}, norm={self.norm is not None}"
+
 
 class TransformerDecoder(nn.Module):
     def __init__(
@@ -271,7 +294,22 @@ class TransformerDecoder(nn.Module):
 
         return output
 
+    def extra_repr(self) -> str:
+        return f"num_layers={self.num_layers}, norm={self.norm is not None}"
 
+
+@nn.auto_repr(
+    "d_model",
+    "num_heads",
+    "num_encoder_layers",
+    "num_decoder_layers",
+    "dim_feedforward",
+    "dropout",
+    "activation",
+    "layer_norm_eps",
+    "norm_first",
+    "bias",
+)
 class Transformer(nn.Module):
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- add `_add_indent` helper
- provide `extra_repr` and `__repr__` to `Module`
- implement printing for `ParameterList` and `ParameterDict`

## Testing
- `python -m compileall -q lucid`
- manual sanity check of `Net()` representation

------
https://chatgpt.com/codex/tasks/task_e_68551e7d7940832e85a4c07b8e3200b8