### PR TITLE
Add preconfigured FasterRCNN builders

### DIFF
--- a/lucid/models/objdet/fast_rcnn.py
+++ b/lucid/models/objdet/fast_rcnn.py
@@ -6,7 +6,7 @@ import lucid.nn.functional as F
 from lucid._tensor import Tensor
 
 from lucid.models.objdet.util import (
-    ROIPool,
+    ROIAlign,
     SelectiveSearch,
     apply_deltas,
     nms,
@@ -32,7 +32,7 @@ class FastRCNN(nn.Module):
     ) -> None:
         super().__init__()
         self.backbone = backbone
-        self.roipool = ROIPool(output_size=pool_size)
+        self.roipool = ROIAlign(output_size=pool_size)
         self.proposal_generator = proposal_generator or SelectiveSearch()
 
         self.fc1 = nn.Linear(feat_channels * pool_size[0] * pool_size[1], hidden_dim)

--- a/lucid/models/registry.json
+++ b/lucid/models/registry.json
@@ -886,5 +886,17 @@
         "family": "MaxViT",
         "param_size": 383734024,
         "task": "imgclf"
+    },
+    "faster_rcnn_resnet50": {
+        "name": "faster_rcnn_resnet50",
+        "family": "FasterRCNN",
+        "param_size": 489383071,
+        "task": "objdet"
+    },
+    "faster_rcnn_mobilenet_v3": {
+        "name": "faster_rcnn_mobilenet_v3",
+        "family": "FasterRCNN",
+        "param_size": 220974821,
+        "task": "objdet"
     }
 }

--- a/lucid/models/registry.json
+++ b/lucid/models/registry.json
@@ -887,16 +887,16 @@
         "param_size": 383734024,
         "task": "imgclf"
     },
-    "faster_rcnn_resnet50": {
-        "name": "faster_rcnn_resnet50",
+    "faster_rcnn_resnet_50_fpn": {
+        "name": "faster_rcnn_resnet_50_fpn",
         "family": "FasterRCNN",
-        "param_size": 489383071,
+        "param_size": 43515902,
         "task": "objdet"
     },
-    "faster_rcnn_mobilenet_v3": {
-        "name": "faster_rcnn_mobilenet_v3",
+    "faster_rcnn_resnet_101_fpn": {
+        "name": "faster_rcnn_resnet_101_fpn",
         "family": "FasterRCNN",
-        "param_size": 220974821,
+        "param_size": 62508030,
         "task": "objdet"
     }
 }


### PR DESCRIPTION
## Summary
- add `faster_rcnn_resnet50` and `faster_rcnn_mobilenet_v3`
- include lightweight backbone wrappers for ResNet50 and MobileNetV3
- register these new models

## Testing
- `pip install -e .` *(fails: Invalid version placeholder)*
- `python - <<'PY'
from lucid.models.objdet.faster_rcnn import faster_rcnn_resnet50,faster_rcnn_mobilenet_v3
m1=faster_rcnn_resnet50(num_classes=5)
print('ResNet50 model:',type(m1))
print(str(m1).split('\n')[0])
m2=faster_rcnn_mobilenet_v3(num_classes=5)
print('MobileNetV3 model:',type(m2))
print(str(m2).split('\n')[0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_686e52b0506c832e86c56f4d87e77106