### PR TITLE
Phase 6-9: interpolate / one_hot / rotate / bilinear C++ kernels

### DIFF
--- a/.extensions/cpp_extensions.json
+++ b/.extensions/cpp_extensions.json
@@ -118,6 +118,8 @@
         "lucid/_C/nn/Attention.cpp",
         "lucid/_C/nn/Embedding.cpp",
         "lucid/_C/nn/Spatial.cpp",
+        "lucid/_C/nn/Interpolate.cpp",
+        "lucid/_C/nn/Vision.cpp",
 
         "lucid/_C/random/Random.cpp",
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ out/
 .pytest_cache
 .claude
 .misc
+
+# Build / packaging artifacts
+build/
+*.egg-info/
+phase0_baseline.txt

--- a/lucid/_C/bindings/bind_nn.cpp
+++ b/lucid/_C/bindings/bind_nn.cpp
@@ -13,9 +13,11 @@
 #include "../nn/Linear.h"
 #include "../nn/Loss.h"
 #include "../nn/NormExt.h"
+#include "../nn/Interpolate.h"
 #include "../nn/PoolNd.h"
 #include "../nn/RMSNorm.h"
 #include "../nn/Spatial.h"
+#include "../nn/Vision.h"
 #include "../core/Dtype.h"
 #include "../core/Generator.h"
 #include "../core/TensorImpl.h"
@@ -317,6 +319,37 @@ void register_nn(py::module_& m) {
           py::arg("align_corners") = true,
           "2-D grid sampling. mode: 0=bilinear, 1=nearest. "
           "padding_mode: 0=zeros, 1=border.");
+
+    // ---------- Interpolation family (Phase 6-9) ----------
+    m.def("interpolate_bilinear", &interpolate_bilinear_op,
+          py::arg("input"), py::arg("H_out"), py::arg("W_out"),
+          py::arg("align_corners") = false,
+          "2-D bilinear interpolation. Input: (N, C, H, W).");
+    m.def("interpolate_trilinear", &interpolate_trilinear_op,
+          py::arg("input"), py::arg("D_out"), py::arg("H_out"), py::arg("W_out"),
+          py::arg("align_corners") = false,
+          "3-D trilinear interpolation. Input: (N, C, D, H, W).");
+    m.def("interpolate_nearest_2d", &interpolate_nearest_2d_op,
+          py::arg("input"), py::arg("H_out"), py::arg("W_out"),
+          "2-D nearest-neighbor interpolation (no autograd).");
+    m.def("interpolate_nearest_3d", &interpolate_nearest_3d_op,
+          py::arg("input"), py::arg("D_out"), py::arg("H_out"), py::arg("W_out"),
+          "3-D nearest-neighbor interpolation (no autograd).");
+
+    // ---------- Vision (Phase 6-9) ----------
+    m.def("one_hot", &one_hot_op,
+          py::arg("input"), py::arg("num_classes"),
+          py::arg("dtype") = Dtype::I8,
+          "One-hot encode integer indices. Output shape: input.shape + (C,).");
+    m.def("rotate", &rotate_op,
+          py::arg("input"), py::arg("angle_deg"),
+          py::arg("cy"), py::arg("cx"),
+          "2-D image rotation (nearest-neighbor; no autograd).");
+    m.def("bilinear_layer", &bilinear_layer_op,
+          py::arg("x1"), py::arg("x2"), py::arg("weight"),
+          py::arg("bias") = TensorImplPtr{},
+          "Learned bilinear layer: y = x1 W x2 + b. "
+          "x1: (..., D1), x2: (..., D2), W: (Dout, D1, D2), b: (Dout,).");
 }
 
 }  // namespace lucid::bindings

--- a/lucid/_C/nn/Interpolate.cpp
+++ b/lucid/_C/nn/Interpolate.cpp
@@ -1,0 +1,777 @@
+#include "Interpolate.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+#include <mlx/ops.h>
+
+#include "../backend/gpu/MlxBridge.h"
+#include "../core/Allocator.h"
+#include "../core/Exceptions.h"
+#include "../core/GradMode.h"
+#include "../core/OpRegistry.h"
+#include "../core/Profiler.h"
+#include "../core/TensorImpl.h"
+#include "../autograd/AccumulateGrad.h"
+#include "../autograd/Helpers.h"
+#include "../autograd/Node.h"
+#include "../ops/bfunc/_BinaryOp.h"
+
+namespace lucid {
+
+namespace {
+
+CpuStorage allocate_size(std::size_t numel, Dtype dt) {
+    CpuStorage s;
+    s.dtype  = dt;
+    s.nbytes = numel * dtype_size(dt);
+    s.ptr    = allocate_aligned_bytes(s.nbytes);
+    return s;
+}
+
+template <typename T>
+inline T src_coord(int out_idx, int in_dim, int out_dim, bool align_corners) {
+    if (align_corners) {
+        if (out_dim <= 1) return T{0};
+        return static_cast<T>(out_idx) * static_cast<T>(in_dim - 1)
+                / static_cast<T>(out_dim - 1);
+    }
+    const T x = (static_cast<T>(out_idx) + T{0.5})
+                * static_cast<T>(in_dim) / static_cast<T>(out_dim) - T{0.5};
+    return x;
+}
+
+inline ::mlx::core::array mlx_scalar(double v, ::mlx::core::Dtype dt) {
+    return ::mlx::core::astype(::mlx::core::array(static_cast<float>(v)), dt);
+}
+
+// Build a 1-D MLX array of source-coordinates of length out_dim.
+::mlx::core::array build_src_coords(int in_dim, int out_dim, bool align_corners,
+                                      ::mlx::core::Dtype dt) {
+    auto idx = ::mlx::core::astype(::mlx::core::arange(0, out_dim, 1), dt);
+    if (align_corners) {
+        if (out_dim <= 1) return ::mlx::core::zeros({out_dim}, dt);
+        auto step = mlx_scalar(static_cast<double>(in_dim - 1) /
+                                 static_cast<double>(out_dim - 1), dt);
+        return ::mlx::core::multiply(idx, step);
+    }
+    auto half = mlx_scalar(0.5, dt);
+    auto scale = mlx_scalar(static_cast<double>(in_dim) /
+                              static_cast<double>(out_dim), dt);
+    auto a = ::mlx::core::add(idx, half);
+    return ::mlx::core::subtract(::mlx::core::multiply(a, scale), half);
+}
+
+}  // namespace
+
+// =====================================================================
+// interpolate_bilinear (4-D)
+// =====================================================================
+
+const OpSchema InterpolateBilinearBackward::schema_v1{
+    "interpolate_bilinear", 1, AmpPolicy::Promote, true};
+
+namespace {
+
+template <typename T>
+void bilinear_forward_cpu(const T* xp, T* op,
+                           int N, int C, int H_in, int W_in,
+                           int H_out, int W_out, bool align_corners) {
+    const std::size_t in_chan  = static_cast<std::size_t>(H_in)  * W_in;
+    const std::size_t out_chan = static_cast<std::size_t>(H_out) * W_out;
+    for (int n = 0; n < N; ++n) {
+        for (int c = 0; c < C; ++c) {
+            for (int h = 0; h < H_out; ++h) {
+                T iy = src_coord<T>(h, H_in, H_out, align_corners);
+                if (iy < T{0}) iy = T{0};
+                if (iy > static_cast<T>(H_in - 1)) iy = static_cast<T>(H_in - 1);
+                int y0 = static_cast<int>(std::floor(iy));
+                int y1 = std::min(y0 + 1, H_in - 1);
+                const T dy = iy - static_cast<T>(y0);
+                for (int w = 0; w < W_out; ++w) {
+                    T ix = src_coord<T>(w, W_in, W_out, align_corners);
+                    if (ix < T{0}) ix = T{0};
+                    if (ix > static_cast<T>(W_in - 1)) ix = static_cast<T>(W_in - 1);
+                    int x0 = static_cast<int>(std::floor(ix));
+                    int x1 = std::min(x0 + 1, W_in - 1);
+                    const T dx = ix - static_cast<T>(x0);
+                    const T w00 = (T{1} - dy) * (T{1} - dx);
+                    const T w01 = (T{1} - dy) * dx;
+                    const T w10 = dy * (T{1} - dx);
+                    const T w11 = dy * dx;
+                    const T* base = xp + (n * C + c) * in_chan;
+                    op[(n * C + c) * out_chan + h * W_out + w] =
+                        base[y0 * W_in + x0] * w00 +
+                        base[y0 * W_in + x1] * w01 +
+                        base[y1 * W_in + x0] * w10 +
+                        base[y1 * W_in + x1] * w11;
+                }
+            }
+        }
+    }
+}
+
+template <typename T>
+void bilinear_backward_cpu(const T* go_p, T* dx_p,
+                            int N, int C, int H_in, int W_in,
+                            int H_out, int W_out, bool align_corners) {
+    const std::size_t in_chan  = static_cast<std::size_t>(H_in)  * W_in;
+    const std::size_t out_chan = static_cast<std::size_t>(H_out) * W_out;
+    std::memset(dx_p, 0, sizeof(T) * static_cast<std::size_t>(N) * C * in_chan);
+    for (int n = 0; n < N; ++n) {
+        for (int c = 0; c < C; ++c) {
+            for (int h = 0; h < H_out; ++h) {
+                T iy = src_coord<T>(h, H_in, H_out, align_corners);
+                if (iy < T{0}) iy = T{0};
+                if (iy > static_cast<T>(H_in - 1)) iy = static_cast<T>(H_in - 1);
+                int y0 = static_cast<int>(std::floor(iy));
+                int y1 = std::min(y0 + 1, H_in - 1);
+                const T dy = iy - static_cast<T>(y0);
+                for (int w = 0; w < W_out; ++w) {
+                    T ix = src_coord<T>(w, W_in, W_out, align_corners);
+                    if (ix < T{0}) ix = T{0};
+                    if (ix > static_cast<T>(W_in - 1)) ix = static_cast<T>(W_in - 1);
+                    int x0 = static_cast<int>(std::floor(ix));
+                    int x1 = std::min(x0 + 1, W_in - 1);
+                    const T dx = ix - static_cast<T>(x0);
+                    const T w00 = (T{1} - dy) * (T{1} - dx);
+                    const T w01 = (T{1} - dy) * dx;
+                    const T w10 = dy * (T{1} - dx);
+                    const T w11 = dy * dx;
+                    const T g = go_p[(n * C + c) * out_chan + h * W_out + w];
+                    T* base = dx_p + (n * C + c) * in_chan;
+                    base[y0 * W_in + x0] += g * w00;
+                    base[y0 * W_in + x1] += g * w01;
+                    base[y1 * W_in + x0] += g * w10;
+                    base[y1 * W_in + x1] += g * w11;
+                }
+            }
+        }
+    }
+}
+
+// GPU helper: gather input at integer (y, x) indices using flat-index take.
+// y/x: shape [H_out, W_out] int64. Result: [N, C, H_out, W_out].
+::mlx::core::array gather_2d_corner(const ::mlx::core::array& input,
+                                      const ::mlx::core::array& y_idx,
+                                      const ::mlx::core::array& x_idx,
+                                      int N, int C, int H_in, int W_in,
+                                      int H_out, int W_out) {
+    auto n_idx = ::mlx::core::reshape(
+        ::mlx::core::astype(::mlx::core::arange(0, N, 1), ::mlx::core::int64),
+        {N, 1, 1, 1});
+    auto c_idx = ::mlx::core::reshape(
+        ::mlx::core::astype(::mlx::core::arange(0, C, 1), ::mlx::core::int64),
+        {1, C, 1, 1});
+    auto y_b = ::mlx::core::reshape(y_idx, {1, 1, H_out, W_out});
+    auto x_b = ::mlx::core::reshape(x_idx, {1, 1, H_out, W_out});
+    auto sn = ::mlx::core::astype(::mlx::core::array(C * H_in * W_in), ::mlx::core::int64);
+    auto sc = ::mlx::core::astype(::mlx::core::array(H_in * W_in), ::mlx::core::int64);
+    auto sy = ::mlx::core::astype(::mlx::core::array(W_in), ::mlx::core::int64);
+    auto flat = ::mlx::core::add(
+        ::mlx::core::add(::mlx::core::multiply(n_idx, sn),
+                          ::mlx::core::multiply(c_idx, sc)),
+        ::mlx::core::add(::mlx::core::multiply(y_b, sy), x_b));
+    auto flat_b = ::mlx::core::broadcast_to(flat, {N, C, H_out, W_out});
+    auto in_flat = ::mlx::core::reshape(input, {N * C * H_in * W_in});
+    return ::mlx::core::take(in_flat, flat_b);
+}
+
+}  // namespace
+
+TensorImplPtr InterpolateBilinearBackward::forward(const TensorImplPtr& input,
+                                                     int H_out, int W_out,
+                                                     bool align_corners) {
+    if (!input) throw LucidError("interpolate_bilinear: null input");
+    if (input->shape_.size() != 4)
+        throw ShapeMismatch(input->shape_, Shape{},
+                             "interpolate_bilinear: input must be 4-D (N, C, H, W)");
+    const int N = static_cast<int>(input->shape_[0]);
+    const int C = static_cast<int>(input->shape_[1]);
+    const int H_in = static_cast<int>(input->shape_[2]);
+    const int W_in = static_cast<int>(input->shape_[3]);
+    Shape out_shape{N, C, H_out, W_out};
+    OpScope scope{schema_v1.name, input->device_, input->dtype_, out_shape};
+
+    Storage out_storage;
+    if (input->device_ == Device::GPU) {
+        const auto& gx = std::get<GpuStorage>(input->storage_);
+        const auto mlx_dt = gpu::to_mlx_dtype(input->dtype_);
+        // Build float source coordinates [H_out] / [W_out], clip to bounds.
+        auto ys = build_src_coords(H_in, H_out, align_corners, mlx_dt);
+        auto xs = build_src_coords(W_in, W_out, align_corners, mlx_dt);
+        auto zero = mlx_scalar(0.0, mlx_dt);
+        auto Hm1 = mlx_scalar(H_in - 1, mlx_dt);
+        auto Wm1 = mlx_scalar(W_in - 1, mlx_dt);
+        ys = ::mlx::core::clip(ys, std::optional<::mlx::core::array>(zero),
+                                  std::optional<::mlx::core::array>(Hm1));
+        xs = ::mlx::core::clip(xs, std::optional<::mlx::core::array>(zero),
+                                  std::optional<::mlx::core::array>(Wm1));
+        auto y0_f = ::mlx::core::floor(ys);
+        auto x0_f = ::mlx::core::floor(xs);
+        auto dy = ::mlx::core::subtract(ys, y0_f);
+        auto dx = ::mlx::core::subtract(xs, x0_f);
+        auto y0 = ::mlx::core::astype(y0_f, ::mlx::core::int64);
+        auto x0 = ::mlx::core::astype(x0_f, ::mlx::core::int64);
+        auto Hm1_i = ::mlx::core::astype(::mlx::core::array(H_in - 1), ::mlx::core::int64);
+        auto Wm1_i = ::mlx::core::astype(::mlx::core::array(W_in - 1), ::mlx::core::int64);
+        auto y1 = ::mlx::core::minimum(::mlx::core::add(y0,
+                            ::mlx::core::astype(::mlx::core::array(1), ::mlx::core::int64)),
+                          Hm1_i);
+        auto x1 = ::mlx::core::minimum(::mlx::core::add(x0,
+                            ::mlx::core::astype(::mlx::core::array(1), ::mlx::core::int64)),
+                          Wm1_i);
+        // Broadcast to 2-D index arrays [H_out, W_out].
+        auto y0_2d = ::mlx::core::broadcast_to(::mlx::core::reshape(y0, {H_out, 1}),
+                                                 {H_out, W_out});
+        auto y1_2d = ::mlx::core::broadcast_to(::mlx::core::reshape(y1, {H_out, 1}),
+                                                 {H_out, W_out});
+        auto x0_2d = ::mlx::core::broadcast_to(::mlx::core::reshape(x0, {1, W_out}),
+                                                 {H_out, W_out});
+        auto x1_2d = ::mlx::core::broadcast_to(::mlx::core::reshape(x1, {1, W_out}),
+                                                 {H_out, W_out});
+        auto I00 = gather_2d_corner(*gx.arr, y0_2d, x0_2d, N, C, H_in, W_in, H_out, W_out);
+        auto I01 = gather_2d_corner(*gx.arr, y0_2d, x1_2d, N, C, H_in, W_in, H_out, W_out);
+        auto I10 = gather_2d_corner(*gx.arr, y1_2d, x0_2d, N, C, H_in, W_in, H_out, W_out);
+        auto I11 = gather_2d_corner(*gx.arr, y1_2d, x1_2d, N, C, H_in, W_in, H_out, W_out);
+        // Build weights [1, 1, H_out, W_out].
+        auto one = mlx_scalar(1.0, mlx_dt);
+        auto dy_2d = ::mlx::core::broadcast_to(::mlx::core::reshape(dy, {1, 1, H_out, 1}),
+                                                 {1, 1, H_out, W_out});
+        auto dx_2d = ::mlx::core::broadcast_to(::mlx::core::reshape(dx, {1, 1, 1, W_out}),
+                                                 {1, 1, H_out, W_out});
+        auto omdy = ::mlx::core::subtract(one, dy_2d);
+        auto omdx = ::mlx::core::subtract(one, dx_2d);
+        auto w00 = ::mlx::core::multiply(omdy, omdx);
+        auto w01 = ::mlx::core::multiply(omdy, dx_2d);
+        auto w10 = ::mlx::core::multiply(dy_2d, omdx);
+        auto w11 = ::mlx::core::multiply(dy_2d, dx_2d);
+        auto y_out = ::mlx::core::add(
+            ::mlx::core::add(::mlx::core::multiply(I00, w00),
+                              ::mlx::core::multiply(I01, w01)),
+            ::mlx::core::add(::mlx::core::multiply(I10, w10),
+                              ::mlx::core::multiply(I11, w11)));
+        out_storage = Storage{gpu::wrap_mlx_array(std::move(y_out), input->dtype_)};
+    } else {
+        auto out_cpu = allocate_size(static_cast<std::size_t>(N) * C * H_out * W_out,
+                                      input->dtype_);
+        const auto& xs = std::get<CpuStorage>(input->storage_);
+        if (input->dtype_ == Dtype::F32) {
+            bilinear_forward_cpu<float>(
+                reinterpret_cast<const float*>(xs.ptr.get()),
+                reinterpret_cast<float*>(out_cpu.ptr.get()),
+                N, C, H_in, W_in, H_out, W_out, align_corners);
+        } else if (input->dtype_ == Dtype::F64) {
+            bilinear_forward_cpu<double>(
+                reinterpret_cast<const double*>(xs.ptr.get()),
+                reinterpret_cast<double*>(out_cpu.ptr.get()),
+                N, C, H_in, W_in, H_out, W_out, align_corners);
+        } else {
+            throw NotImplementedError(
+                "interpolate_bilinear: dtype must be F32/F64");
+        }
+        out_storage = Storage{std::move(out_cpu)};
+    }
+
+    auto out = std::make_shared<TensorImpl>(std::move(out_storage),
+                                             out_shape, input->dtype_,
+                                             input->device_, false);
+    if (!GradMode::is_enabled() || !input->requires_grad_) return out;
+    auto x_edge = detail::ensure_grad_fn(input);
+    auto bwd = std::make_shared<InterpolateBilinearBackward>();
+    bwd->input_shapes_ = {input->shape_};
+    bwd->out_shape_    = out_shape;
+    bwd->dtype_        = input->dtype_;
+    bwd->device_       = input->device_;
+    bwd->input_tensors_ = {input};
+    bwd->H_in_ = H_in; bwd->W_in_ = W_in;
+    bwd->H_out_ = H_out; bwd->W_out_ = W_out;
+    bwd->align_corners_ = align_corners;
+    bwd->orig_shape_ = input->shape_;
+    bwd->set_next_edges(std::vector<Edge>{Edge(x_edge, 0)});
+    bwd->set_saved_versions({input->version_});
+    out->grad_fn_ = std::move(bwd);
+    out->is_leaf_ = false;
+    out->requires_grad_ = true;
+    return out;
+}
+
+std::vector<Storage> InterpolateBilinearBackward::apply(Storage grad_out) {
+    const int N = static_cast<int>(orig_shape_[0]);
+    const int C = static_cast<int>(orig_shape_[1]);
+    if (device_ == Device::GPU) {
+        // GPU backward: download → CPU scatter-add → upload (correctness-first).
+        auto go_cpu = gpu::download_gpu_to_cpu(
+            std::get<GpuStorage>(grad_out), out_shape_);
+        auto dx_cpu = allocate_size(
+            static_cast<std::size_t>(N) * C * H_in_ * W_in_, dtype_);
+        if (dtype_ == Dtype::F32) {
+            bilinear_backward_cpu<float>(
+                reinterpret_cast<const float*>(go_cpu.ptr.get()),
+                reinterpret_cast<float*>(dx_cpu.ptr.get()),
+                N, C, H_in_, W_in_, H_out_, W_out_, align_corners_);
+        } else if (dtype_ == Dtype::F64) {
+            bilinear_backward_cpu<double>(
+                reinterpret_cast<const double*>(go_cpu.ptr.get()),
+                reinterpret_cast<double*>(dx_cpu.ptr.get()),
+                N, C, H_in_, W_in_, H_out_, W_out_, align_corners_);
+        } else {
+            throw NotImplementedError(
+                "interpolate_bilinear backward: dtype not supported");
+        }
+        return {Storage{gpu::upload_cpu_to_gpu(dx_cpu, orig_shape_)}};
+    }
+    auto dx_cpu = allocate_size(
+        static_cast<std::size_t>(N) * C * H_in_ * W_in_, dtype_);
+    const auto& go = std::get<CpuStorage>(grad_out);
+    if (dtype_ == Dtype::F32) {
+        bilinear_backward_cpu<float>(
+            reinterpret_cast<const float*>(go.ptr.get()),
+            reinterpret_cast<float*>(dx_cpu.ptr.get()),
+            N, C, H_in_, W_in_, H_out_, W_out_, align_corners_);
+    } else if (dtype_ == Dtype::F64) {
+        bilinear_backward_cpu<double>(
+            reinterpret_cast<const double*>(go.ptr.get()),
+            reinterpret_cast<double*>(dx_cpu.ptr.get()),
+            N, C, H_in_, W_in_, H_out_, W_out_, align_corners_);
+    } else {
+        throw NotImplementedError(
+            "interpolate_bilinear backward: dtype not supported");
+    }
+    return {Storage{std::move(dx_cpu)}};
+}
+
+TensorImplPtr interpolate_bilinear_op(const TensorImplPtr& input,
+                                        int H_out, int W_out, bool align_corners) {
+    return InterpolateBilinearBackward::forward(input, H_out, W_out, align_corners);
+}
+LUCID_REGISTER_OP(InterpolateBilinearBackward)
+
+// =====================================================================
+// interpolate_trilinear (5-D)
+// =====================================================================
+
+const OpSchema InterpolateTrilinearBackward::schema_v1{
+    "interpolate_trilinear", 1, AmpPolicy::Promote, true};
+
+namespace {
+
+template <typename T>
+void trilinear_forward_cpu(const T* xp, T* op,
+                            int N, int C, int D_in, int H_in, int W_in,
+                            int D_out, int H_out, int W_out, bool align) {
+    const std::size_t in_chan  = static_cast<std::size_t>(D_in)  * H_in  * W_in;
+    const std::size_t out_chan = static_cast<std::size_t>(D_out) * H_out * W_out;
+    auto coord = [&](int o, int in_n, int out_n) {
+        T v = src_coord<T>(o, in_n, out_n, align);
+        if (v < T{0}) v = T{0};
+        if (v > static_cast<T>(in_n - 1)) v = static_cast<T>(in_n - 1);
+        return v;
+    };
+    for (int n = 0; n < N; ++n)
+    for (int c = 0; c < C; ++c) {
+        const T* base = xp + (n * C + c) * in_chan;
+        T* out_base = op + (n * C + c) * out_chan;
+        for (int d = 0; d < D_out; ++d) {
+            T iz = coord(d, D_in, D_out);
+            int z0 = static_cast<int>(std::floor(iz));
+            int z1 = std::min(z0 + 1, D_in - 1);
+            const T dz = iz - static_cast<T>(z0);
+            for (int h = 0; h < H_out; ++h) {
+                T iy = coord(h, H_in, H_out);
+                int y0 = static_cast<int>(std::floor(iy));
+                int y1 = std::min(y0 + 1, H_in - 1);
+                const T dy = iy - static_cast<T>(y0);
+                for (int w = 0; w < W_out; ++w) {
+                    T ix = coord(w, W_in, W_out);
+                    int x0 = static_cast<int>(std::floor(ix));
+                    int x1 = std::min(x0 + 1, W_in - 1);
+                    const T dx = ix - static_cast<T>(x0);
+                    auto idx = [&](int z, int y, int x) -> std::size_t {
+                        return static_cast<std::size_t>(z) * H_in * W_in
+                              + static_cast<std::size_t>(y) * W_in + x;
+                    };
+                    const T c000 = base[idx(z0, y0, x0)];
+                    const T c001 = base[idx(z0, y0, x1)];
+                    const T c010 = base[idx(z0, y1, x0)];
+                    const T c011 = base[idx(z0, y1, x1)];
+                    const T c100 = base[idx(z1, y0, x0)];
+                    const T c101 = base[idx(z1, y0, x1)];
+                    const T c110 = base[idx(z1, y1, x0)];
+                    const T c111 = base[idx(z1, y1, x1)];
+                    const T c00 = c000 * (T{1} - dx) + c001 * dx;
+                    const T c01 = c010 * (T{1} - dx) + c011 * dx;
+                    const T c10 = c100 * (T{1} - dx) + c101 * dx;
+                    const T c11 = c110 * (T{1} - dx) + c111 * dx;
+                    const T c0 = c00 * (T{1} - dy) + c01 * dy;
+                    const T c1 = c10 * (T{1} - dy) + c11 * dy;
+                    out_base[d * H_out * W_out + h * W_out + w] =
+                        c0 * (T{1} - dz) + c1 * dz;
+                }
+            }
+        }
+    }
+}
+
+template <typename T>
+void trilinear_backward_cpu(const T* go_p, T* dx_p,
+                             int N, int C, int D_in, int H_in, int W_in,
+                             int D_out, int H_out, int W_out, bool align) {
+    const std::size_t in_chan  = static_cast<std::size_t>(D_in)  * H_in  * W_in;
+    const std::size_t out_chan = static_cast<std::size_t>(D_out) * H_out * W_out;
+    std::memset(dx_p, 0, sizeof(T) * static_cast<std::size_t>(N) * C * in_chan);
+    auto coord = [&](int o, int in_n, int out_n) {
+        T v = src_coord<T>(o, in_n, out_n, align);
+        if (v < T{0}) v = T{0};
+        if (v > static_cast<T>(in_n - 1)) v = static_cast<T>(in_n - 1);
+        return v;
+    };
+    for (int n = 0; n < N; ++n)
+    for (int c = 0; c < C; ++c) {
+        T* base = dx_p + (n * C + c) * in_chan;
+        const T* go_base = go_p + (n * C + c) * out_chan;
+        for (int d = 0; d < D_out; ++d) {
+            T iz = coord(d, D_in, D_out);
+            int z0 = static_cast<int>(std::floor(iz));
+            int z1 = std::min(z0 + 1, D_in - 1);
+            const T dz = iz - static_cast<T>(z0);
+            for (int h = 0; h < H_out; ++h) {
+                T iy = coord(h, H_in, H_out);
+                int y0 = static_cast<int>(std::floor(iy));
+                int y1 = std::min(y0 + 1, H_in - 1);
+                const T dy = iy - static_cast<T>(y0);
+                for (int w = 0; w < W_out; ++w) {
+                    T ix = coord(w, W_in, W_out);
+                    int x0 = static_cast<int>(std::floor(ix));
+                    int x1 = std::min(x0 + 1, W_in - 1);
+                    const T dx = ix - static_cast<T>(x0);
+                    const T g = go_base[d * H_out * W_out + h * W_out + w];
+                    auto add = [&](int z, int y, int x, T weight) {
+                        base[static_cast<std::size_t>(z) * H_in * W_in
+                              + static_cast<std::size_t>(y) * W_in + x]
+                          += g * weight;
+                    };
+                    const T omdx = T{1} - dx, omdy = T{1} - dy, omdz = T{1} - dz;
+                    add(z0, y0, x0, omdz * omdy * omdx);
+                    add(z0, y0, x1, omdz * omdy * dx);
+                    add(z0, y1, x0, omdz * dy * omdx);
+                    add(z0, y1, x1, omdz * dy * dx);
+                    add(z1, y0, x0, dz * omdy * omdx);
+                    add(z1, y0, x1, dz * omdy * dx);
+                    add(z1, y1, x0, dz * dy * omdx);
+                    add(z1, y1, x1, dz * dy * dx);
+                }
+            }
+        }
+    }
+}
+
+}  // namespace
+
+TensorImplPtr InterpolateTrilinearBackward::forward(const TensorImplPtr& input,
+                                                      int D_out, int H_out, int W_out,
+                                                      bool align_corners) {
+    if (!input) throw LucidError("interpolate_trilinear: null input");
+    if (input->shape_.size() != 5)
+        throw ShapeMismatch(input->shape_, Shape{},
+                             "interpolate_trilinear: input must be 5-D");
+    const int N = static_cast<int>(input->shape_[0]);
+    const int C = static_cast<int>(input->shape_[1]);
+    const int D_in = static_cast<int>(input->shape_[2]);
+    const int H_in = static_cast<int>(input->shape_[3]);
+    const int W_in = static_cast<int>(input->shape_[4]);
+    Shape out_shape{N, C, D_out, H_out, W_out};
+    OpScope scope{schema_v1.name, input->device_, input->dtype_, out_shape};
+
+    Storage out_storage;
+    if (input->device_ == Device::GPU) {
+        // GPU forward: download → CPU compute → upload. Trilinear is rare
+        // enough that maintaining a parallel MLX implementation is not worth
+        // the complexity; backward also reuses CPU.
+        auto x_cpu = gpu::download_gpu_to_cpu(
+            std::get<GpuStorage>(input->storage_), input->shape_);
+        auto out_cpu = allocate_size(
+            static_cast<std::size_t>(N) * C * D_out * H_out * W_out,
+            input->dtype_);
+        if (input->dtype_ == Dtype::F32)
+            trilinear_forward_cpu<float>(
+                reinterpret_cast<const float*>(x_cpu.ptr.get()),
+                reinterpret_cast<float*>(out_cpu.ptr.get()),
+                N, C, D_in, H_in, W_in, D_out, H_out, W_out, align_corners);
+        else if (input->dtype_ == Dtype::F64)
+            trilinear_forward_cpu<double>(
+                reinterpret_cast<const double*>(x_cpu.ptr.get()),
+                reinterpret_cast<double*>(out_cpu.ptr.get()),
+                N, C, D_in, H_in, W_in, D_out, H_out, W_out, align_corners);
+        else
+            throw NotImplementedError("interpolate_trilinear: dtype must be F32/F64");
+        out_storage = Storage{gpu::upload_cpu_to_gpu(out_cpu, out_shape)};
+    } else {
+        auto out_cpu = allocate_size(
+            static_cast<std::size_t>(N) * C * D_out * H_out * W_out,
+            input->dtype_);
+        const auto& xs = std::get<CpuStorage>(input->storage_);
+        if (input->dtype_ == Dtype::F32)
+            trilinear_forward_cpu<float>(
+                reinterpret_cast<const float*>(xs.ptr.get()),
+                reinterpret_cast<float*>(out_cpu.ptr.get()),
+                N, C, D_in, H_in, W_in, D_out, H_out, W_out, align_corners);
+        else if (input->dtype_ == Dtype::F64)
+            trilinear_forward_cpu<double>(
+                reinterpret_cast<const double*>(xs.ptr.get()),
+                reinterpret_cast<double*>(out_cpu.ptr.get()),
+                N, C, D_in, H_in, W_in, D_out, H_out, W_out, align_corners);
+        else
+            throw NotImplementedError("interpolate_trilinear: dtype must be F32/F64");
+        out_storage = Storage{std::move(out_cpu)};
+    }
+
+    auto out = std::make_shared<TensorImpl>(std::move(out_storage),
+                                             out_shape, input->dtype_,
+                                             input->device_, false);
+    if (!GradMode::is_enabled() || !input->requires_grad_) return out;
+    auto x_edge = detail::ensure_grad_fn(input);
+    auto bwd = std::make_shared<InterpolateTrilinearBackward>();
+    bwd->input_shapes_ = {input->shape_};
+    bwd->out_shape_    = out_shape;
+    bwd->dtype_        = input->dtype_;
+    bwd->device_       = input->device_;
+    bwd->input_tensors_ = {input};
+    bwd->D_in_ = D_in; bwd->H_in_ = H_in; bwd->W_in_ = W_in;
+    bwd->D_out_ = D_out; bwd->H_out_ = H_out; bwd->W_out_ = W_out;
+    bwd->align_corners_ = align_corners;
+    bwd->orig_shape_ = input->shape_;
+    bwd->set_next_edges(std::vector<Edge>{Edge(x_edge, 0)});
+    bwd->set_saved_versions({input->version_});
+    out->grad_fn_ = std::move(bwd);
+    out->is_leaf_ = false;
+    out->requires_grad_ = true;
+    return out;
+}
+
+std::vector<Storage> InterpolateTrilinearBackward::apply(Storage grad_out) {
+    const int N = static_cast<int>(orig_shape_[0]);
+    const int C = static_cast<int>(orig_shape_[1]);
+    auto dx_cpu = allocate_size(
+        static_cast<std::size_t>(N) * C * D_in_ * H_in_ * W_in_, dtype_);
+
+    CpuStorage go_cpu_buf;
+    const CpuStorage* go_ptr = nullptr;
+    if (device_ == Device::GPU) {
+        go_cpu_buf = gpu::download_gpu_to_cpu(
+            std::get<GpuStorage>(grad_out), out_shape_);
+        go_ptr = &go_cpu_buf;
+    } else {
+        go_ptr = &std::get<CpuStorage>(grad_out);
+    }
+    if (dtype_ == Dtype::F32)
+        trilinear_backward_cpu<float>(
+            reinterpret_cast<const float*>(go_ptr->ptr.get()),
+            reinterpret_cast<float*>(dx_cpu.ptr.get()),
+            N, C, D_in_, H_in_, W_in_, D_out_, H_out_, W_out_, align_corners_);
+    else if (dtype_ == Dtype::F64)
+        trilinear_backward_cpu<double>(
+            reinterpret_cast<const double*>(go_ptr->ptr.get()),
+            reinterpret_cast<double*>(dx_cpu.ptr.get()),
+            N, C, D_in_, H_in_, W_in_, D_out_, H_out_, W_out_, align_corners_);
+    else
+        throw NotImplementedError("interpolate_trilinear backward: dtype not supported");
+
+    if (device_ == Device::GPU) {
+        return {Storage{gpu::upload_cpu_to_gpu(dx_cpu, orig_shape_)}};
+    }
+    return {Storage{std::move(dx_cpu)}};
+}
+
+TensorImplPtr interpolate_trilinear_op(const TensorImplPtr& input,
+                                          int D_out, int H_out, int W_out,
+                                          bool align_corners) {
+    return InterpolateTrilinearBackward::forward(input, D_out, H_out, W_out,
+                                                   align_corners);
+}
+LUCID_REGISTER_OP(InterpolateTrilinearBackward)
+
+// =====================================================================
+// interpolate_nearest (no autograd: indices are non-differentiable).
+// =====================================================================
+
+namespace {
+
+template <typename T>
+void nearest2d_cpu(const T* xp, T* op, int N, int C, int H_in, int W_in,
+                    int H_out, int W_out) {
+    for (int n = 0; n < N; ++n)
+    for (int c = 0; c < C; ++c) {
+        const T* base = xp + ((n * C + c) * H_in) * W_in;
+        T* out_base = op + ((n * C + c) * H_out) * W_out;
+        for (int h = 0; h < H_out; ++h) {
+            int yh = static_cast<int>(std::floor(
+                static_cast<double>(h) * H_in / H_out));
+            yh = std::clamp(yh, 0, H_in - 1);
+            for (int w = 0; w < W_out; ++w) {
+                int xw = static_cast<int>(std::floor(
+                    static_cast<double>(w) * W_in / W_out));
+                xw = std::clamp(xw, 0, W_in - 1);
+                out_base[h * W_out + w] = base[yh * W_in + xw];
+            }
+        }
+    }
+}
+
+template <typename T>
+void nearest3d_cpu(const T* xp, T* op,
+                    int N, int C, int D_in, int H_in, int W_in,
+                    int D_out, int H_out, int W_out) {
+    for (int n = 0; n < N; ++n)
+    for (int c = 0; c < C; ++c) {
+        const T* base = xp + (n * C + c) * D_in * H_in * W_in;
+        T* out_base = op + (n * C + c) * D_out * H_out * W_out;
+        for (int d = 0; d < D_out; ++d) {
+            int dz = std::clamp(static_cast<int>(std::floor(
+                static_cast<double>(d) * D_in / D_out)), 0, D_in - 1);
+            for (int h = 0; h < H_out; ++h) {
+                int yh = std::clamp(static_cast<int>(std::floor(
+                    static_cast<double>(h) * H_in / H_out)), 0, H_in - 1);
+                for (int w = 0; w < W_out; ++w) {
+                    int xw = std::clamp(static_cast<int>(std::floor(
+                        static_cast<double>(w) * W_in / W_out)), 0, W_in - 1);
+                    out_base[(d * H_out + h) * W_out + w] =
+                        base[(dz * H_in + yh) * W_in + xw];
+                }
+            }
+        }
+    }
+}
+
+}  // namespace
+
+TensorImplPtr interpolate_nearest_2d_op(const TensorImplPtr& input,
+                                          int H_out, int W_out) {
+    if (!input) throw LucidError("interpolate_nearest: null input");
+    if (input->shape_.size() != 4)
+        throw ShapeMismatch(input->shape_, Shape{},
+                             "interpolate_nearest: 4-D input required");
+    const int N = static_cast<int>(input->shape_[0]);
+    const int C = static_cast<int>(input->shape_[1]);
+    const int H_in = static_cast<int>(input->shape_[2]);
+    const int W_in = static_cast<int>(input->shape_[3]);
+    Shape out_shape{N, C, H_out, W_out};
+    OpScope scope{"interpolate_nearest_2d", input->device_,
+                   input->dtype_, out_shape};
+    Storage out_storage;
+    if (input->device_ == Device::GPU) {
+        const auto& gx = std::get<GpuStorage>(input->storage_);
+        // Build int index arrays: yh[H_out], xw[W_out].
+        ::mlx::core::array yh = ::mlx::core::astype(
+            ::mlx::core::arange(0, H_out, 1), ::mlx::core::float32);
+        ::mlx::core::array xw = ::mlx::core::astype(
+            ::mlx::core::arange(0, W_out, 1), ::mlx::core::float32);
+        auto sH = ::mlx::core::astype(::mlx::core::array(
+            static_cast<float>(H_in) / static_cast<float>(H_out)), ::mlx::core::float32);
+        auto sW = ::mlx::core::astype(::mlx::core::array(
+            static_cast<float>(W_in) / static_cast<float>(W_out)), ::mlx::core::float32);
+        yh = ::mlx::core::floor(::mlx::core::multiply(yh, sH));
+        xw = ::mlx::core::floor(::mlx::core::multiply(xw, sW));
+        auto Hm1 = ::mlx::core::astype(::mlx::core::array(H_in - 1), ::mlx::core::float32);
+        auto Wm1 = ::mlx::core::astype(::mlx::core::array(W_in - 1), ::mlx::core::float32);
+        auto zero_f = ::mlx::core::astype(::mlx::core::array(0.0f), ::mlx::core::float32);
+        yh = ::mlx::core::clip(yh,
+            std::optional<::mlx::core::array>(zero_f),
+            std::optional<::mlx::core::array>(Hm1));
+        xw = ::mlx::core::clip(xw,
+            std::optional<::mlx::core::array>(zero_f),
+            std::optional<::mlx::core::array>(Wm1));
+        auto y_int = ::mlx::core::astype(yh, ::mlx::core::int64);
+        auto x_int = ::mlx::core::astype(xw, ::mlx::core::int64);
+        auto y_2d = ::mlx::core::broadcast_to(::mlx::core::reshape(y_int, {H_out, 1}),
+                                                {H_out, W_out});
+        auto x_2d = ::mlx::core::broadcast_to(::mlx::core::reshape(x_int, {1, W_out}),
+                                                {H_out, W_out});
+        auto out = gather_2d_corner(*gx.arr, y_2d, x_2d,
+                                       N, C, H_in, W_in, H_out, W_out);
+        out_storage = Storage{gpu::wrap_mlx_array(std::move(out), input->dtype_)};
+    } else {
+        auto out_cpu = allocate_size(
+            static_cast<std::size_t>(N) * C * H_out * W_out, input->dtype_);
+        const auto& xs = std::get<CpuStorage>(input->storage_);
+        if (input->dtype_ == Dtype::F32)
+            nearest2d_cpu<float>(
+                reinterpret_cast<const float*>(xs.ptr.get()),
+                reinterpret_cast<float*>(out_cpu.ptr.get()),
+                N, C, H_in, W_in, H_out, W_out);
+        else if (input->dtype_ == Dtype::F64)
+            nearest2d_cpu<double>(
+                reinterpret_cast<const double*>(xs.ptr.get()),
+                reinterpret_cast<double*>(out_cpu.ptr.get()),
+                N, C, H_in, W_in, H_out, W_out);
+        else
+            throw NotImplementedError("interpolate_nearest: dtype must be F32/F64");
+        out_storage = Storage{std::move(out_cpu)};
+    }
+    return std::make_shared<TensorImpl>(std::move(out_storage),
+                                         out_shape, input->dtype_,
+                                         input->device_, false);
+}
+
+TensorImplPtr interpolate_nearest_3d_op(const TensorImplPtr& input,
+                                          int D_out, int H_out, int W_out) {
+    if (!input) throw LucidError("interpolate_nearest_3d: null input");
+    if (input->shape_.size() != 5)
+        throw ShapeMismatch(input->shape_, Shape{},
+                             "interpolate_nearest_3d: 5-D input required");
+    const int N = static_cast<int>(input->shape_[0]);
+    const int C = static_cast<int>(input->shape_[1]);
+    const int D_in = static_cast<int>(input->shape_[2]);
+    const int H_in = static_cast<int>(input->shape_[3]);
+    const int W_in = static_cast<int>(input->shape_[4]);
+    Shape out_shape{N, C, D_out, H_out, W_out};
+    OpScope scope{"interpolate_nearest_3d", input->device_,
+                   input->dtype_, out_shape};
+    Storage out_storage;
+    if (input->device_ == Device::GPU) {
+        // Bridge through CPU for simplicity (5-D gather scaffolding is large).
+        auto x_cpu = gpu::download_gpu_to_cpu(
+            std::get<GpuStorage>(input->storage_), input->shape_);
+        auto out_cpu = allocate_size(
+            static_cast<std::size_t>(N) * C * D_out * H_out * W_out,
+            input->dtype_);
+        if (input->dtype_ == Dtype::F32)
+            nearest3d_cpu<float>(
+                reinterpret_cast<const float*>(x_cpu.ptr.get()),
+                reinterpret_cast<float*>(out_cpu.ptr.get()),
+                N, C, D_in, H_in, W_in, D_out, H_out, W_out);
+        else if (input->dtype_ == Dtype::F64)
+            nearest3d_cpu<double>(
+                reinterpret_cast<const double*>(x_cpu.ptr.get()),
+                reinterpret_cast<double*>(out_cpu.ptr.get()),
+                N, C, D_in, H_in, W_in, D_out, H_out, W_out);
+        else
+            throw NotImplementedError("interpolate_nearest_3d: dtype must be F32/F64");
+        out_storage = Storage{gpu::upload_cpu_to_gpu(out_cpu, out_shape)};
+    } else {
+        auto out_cpu = allocate_size(
+            static_cast<std::size_t>(N) * C * D_out * H_out * W_out,
+            input->dtype_);
+        const auto& xs = std::get<CpuStorage>(input->storage_);
+        if (input->dtype_ == Dtype::F32)
+            nearest3d_cpu<float>(
+                reinterpret_cast<const float*>(xs.ptr.get()),
+                reinterpret_cast<float*>(out_cpu.ptr.get()),
+                N, C, D_in, H_in, W_in, D_out, H_out, W_out);
+        else if (input->dtype_ == Dtype::F64)
+            nearest3d_cpu<double>(
+                reinterpret_cast<const double*>(xs.ptr.get()),
+                reinterpret_cast<double*>(out_cpu.ptr.get()),
+                N, C, D_in, H_in, W_in, D_out, H_out, W_out);
+        else
+            throw NotImplementedError("interpolate_nearest_3d: dtype must be F32/F64");
+        out_storage = Storage{std::move(out_cpu)};
+    }
+    return std::make_shared<TensorImpl>(std::move(out_storage),
+                                         out_shape, input->dtype_,
+                                         input->device_, false);
+}
+
+}  // namespace lucid

--- a/lucid/_C/nn/Interpolate.h
+++ b/lucid/_C/nn/Interpolate.h
@@ -1,0 +1,65 @@
+#pragma once
+
+// =====================================================================
+// Lucid C++ engine — interpolate (bilinear / trilinear / nearest).
+// =====================================================================
+//
+//   interpolate_bilinear (4-D)   input: [N, C, H, W]   → [N, C, H_out, W_out]
+//   interpolate_trilinear (5-D)  input: [N, C, D, H, W] → [N, C, D_out, H_out, W_out]
+//   interpolate_nearest (4-D)    same shapes; no autograd
+//   interpolate_nearest_3d (5-D) same shapes; no autograd
+//
+// align_corners=True : src = i * (in - 1) / (out - 1)
+// align_corners=False: src = (i + 0.5) * in / out - 0.5  (then clamp)
+//
+// "area" is implemented as a Python composition over avg_pool — no kernel
+// needed here.
+
+#include "../api.h"
+#include "../core/AmpPolicy.h"
+#include "../core/OpSchema.h"
+#include "../core/Storage.h"
+#include "../core/fwd.h"
+#include "../autograd/FuncOp.h"
+
+namespace lucid {
+
+class LUCID_API InterpolateBilinearBackward
+    : public FuncOp<InterpolateBilinearBackward, 1> {
+public:
+    static const OpSchema schema_v1;
+    int H_in_ = 0, W_in_ = 0, H_out_ = 0, W_out_ = 0;
+    bool align_corners_ = false;
+    Shape orig_shape_;
+    static TensorImplPtr forward(const TensorImplPtr& input,
+                                  int H_out, int W_out, bool align_corners);
+    std::vector<Storage> apply(Storage grad_out) override;
+};
+
+class LUCID_API InterpolateTrilinearBackward
+    : public FuncOp<InterpolateTrilinearBackward, 1> {
+public:
+    static const OpSchema schema_v1;
+    int D_in_ = 0, H_in_ = 0, W_in_ = 0;
+    int D_out_ = 0, H_out_ = 0, W_out_ = 0;
+    bool align_corners_ = false;
+    Shape orig_shape_;
+    static TensorImplPtr forward(const TensorImplPtr& input,
+                                  int D_out, int H_out, int W_out,
+                                  bool align_corners);
+    std::vector<Storage> apply(Storage grad_out) override;
+};
+
+LUCID_API TensorImplPtr interpolate_bilinear_op(const TensorImplPtr& input,
+                                                  int H_out, int W_out,
+                                                  bool align_corners);
+LUCID_API TensorImplPtr interpolate_trilinear_op(const TensorImplPtr& input,
+                                                   int D_out, int H_out, int W_out,
+                                                   bool align_corners);
+// Nearest-neighbor variants (no autograd — round is non-differentiable).
+LUCID_API TensorImplPtr interpolate_nearest_2d_op(const TensorImplPtr& input,
+                                                    int H_out, int W_out);
+LUCID_API TensorImplPtr interpolate_nearest_3d_op(const TensorImplPtr& input,
+                                                    int D_out, int H_out, int W_out);
+
+}  // namespace lucid

--- a/lucid/_C/nn/Vision.cpp
+++ b/lucid/_C/nn/Vision.cpp
@@ -1,0 +1,548 @@
+#include "Vision.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+#include <mlx/ops.h>
+
+#include "../backend/cpu/Blas.h"
+#include "../backend/gpu/MlxBridge.h"
+#include "../core/Allocator.h"
+#include "../core/Exceptions.h"
+#include "../core/GradMode.h"
+#include "../core/OpRegistry.h"
+#include "../core/Profiler.h"
+#include "../core/TensorImpl.h"
+#include "../autograd/AccumulateGrad.h"
+#include "../autograd/Helpers.h"
+#include "../autograd/Node.h"
+#include "../ops/bfunc/_BinaryOp.h"
+
+namespace lucid {
+
+namespace {
+
+CpuStorage allocate_size(std::size_t numel, Dtype dt) {
+    CpuStorage s;
+    s.dtype  = dt;
+    s.nbytes = numel * dtype_size(dt);
+    s.ptr    = allocate_aligned_bytes(s.nbytes);
+    return s;
+}
+
+inline std::int64_t read_index(const CpuStorage& ts, std::size_t i) {
+    switch (ts.dtype) {
+        case Dtype::I8:  return reinterpret_cast<const std::int8_t*>(ts.ptr.get())[i];
+        case Dtype::I16: return reinterpret_cast<const std::int16_t*>(ts.ptr.get())[i];
+        case Dtype::I32: return reinterpret_cast<const std::int32_t*>(ts.ptr.get())[i];
+        case Dtype::I64: return reinterpret_cast<const std::int64_t*>(ts.ptr.get())[i];
+        case Dtype::Bool: return reinterpret_cast<const std::uint8_t*>(ts.ptr.get())[i];
+        default:
+            throw NotImplementedError("one_hot/rotate: index dtype must be integer");
+    }
+}
+
+}  // namespace
+
+// =====================================================================
+// one_hot — no autograd; integer-indexed scatter.
+// =====================================================================
+
+TensorImplPtr one_hot_op(const TensorImplPtr& input, int num_classes,
+                           Dtype out_dtype) {
+    if (!input) throw LucidError("one_hot: null input");
+    if (num_classes <= 0)
+        throw LucidError("one_hot: num_classes must be > 0");
+    Shape out_shape = input->shape_;
+    out_shape.push_back(num_classes);
+    OpScope scope{"one_hot", input->device_, out_dtype, out_shape};
+
+    if (input->device_ == Device::GPU) {
+        const auto& gi = std::get<GpuStorage>(input->storage_);
+        // arange [num_classes] vs broadcast input → equality.
+        auto cls = ::mlx::core::astype(::mlx::core::arange(0, num_classes, 1),
+                                          ::mlx::core::int64);
+        auto idx = ::mlx::core::astype(*gi.arr, ::mlx::core::int64);
+        // Insert trailing dim, broadcast against arange.
+        ::mlx::core::Shape idx_shape = idx.shape();
+        idx_shape.push_back(1);
+        auto idx_b = ::mlx::core::reshape(idx, idx_shape);
+        ::mlx::core::Shape cls_shape(idx_shape.size(), 1);
+        cls_shape.back() = num_classes;
+        auto cls_b = ::mlx::core::reshape(cls, cls_shape);
+        auto eq = ::mlx::core::equal(idx_b, cls_b);
+        auto mlx_dt = gpu::to_mlx_dtype(out_dtype);
+        auto out = ::mlx::core::astype(eq, mlx_dt);
+        return std::make_shared<TensorImpl>(
+            Storage{gpu::wrap_mlx_array(std::move(out), out_dtype)},
+            out_shape, out_dtype, input->device_, false);
+    }
+    const std::size_t M = input->numel();
+    auto out_cpu = allocate_size(M * static_cast<std::size_t>(num_classes), out_dtype);
+    std::memset(out_cpu.ptr.get(), 0, out_cpu.nbytes);
+    const auto& is_ = std::get<CpuStorage>(input->storage_);
+    auto write_one = [&](std::size_t i, std::int64_t cls) {
+        const std::size_t pos = i * static_cast<std::size_t>(num_classes) + cls;
+        switch (out_dtype) {
+            case Dtype::F32:
+                reinterpret_cast<float*>(out_cpu.ptr.get())[pos] = 1.f; break;
+            case Dtype::F64:
+                reinterpret_cast<double*>(out_cpu.ptr.get())[pos] = 1.0; break;
+            case Dtype::I8: case Dtype::Bool:
+                reinterpret_cast<std::uint8_t*>(out_cpu.ptr.get())[pos] = 1; break;
+            case Dtype::I16:
+                reinterpret_cast<std::int16_t*>(out_cpu.ptr.get())[pos] = 1; break;
+            case Dtype::I32:
+                reinterpret_cast<std::int32_t*>(out_cpu.ptr.get())[pos] = 1; break;
+            case Dtype::I64:
+                reinterpret_cast<std::int64_t*>(out_cpu.ptr.get())[pos] = 1; break;
+            default:
+                throw NotImplementedError("one_hot: output dtype not supported");
+        }
+    };
+    for (std::size_t i = 0; i < M; ++i) {
+        std::int64_t cls = read_index(is_, i);
+        if (cls < 0 || cls >= num_classes) continue;  // PyTorch silently skips
+        write_one(i, cls);
+    }
+    return std::make_shared<TensorImpl>(Storage{std::move(out_cpu)},
+                                         out_shape, out_dtype,
+                                         input->device_, false);
+}
+
+// =====================================================================
+// rotate — no autograd; nearest-neighbor sample with affine matrix.
+// =====================================================================
+
+namespace {
+
+template <typename T>
+void rotate_cpu_kernel(const T* xp, T* op, int N, int C, int H, int W,
+                        double angle_rad_neg, double cx, double cy) {
+    const double c = std::cos(angle_rad_neg);
+    const double s = std::sin(angle_rad_neg);
+    for (int n = 0; n < N; ++n)
+    for (int ch = 0; ch < C; ++ch) {
+        const T* base = xp + (n * C + ch) * H * W;
+        T* obase = op + (n * C + ch) * H * W;
+        for (int y = 0; y < H; ++y) {
+            for (int x = 0; x < W; ++x) {
+                const double xs_d = c * (x - cx) - s * (y - cy) + cx;
+                const double ys_d = s * (x - cx) + c * (y - cy) + cy;
+                int xs = static_cast<int>(std::floor(xs_d + 0.5));
+                int ys = static_cast<int>(std::floor(ys_d + 0.5));
+                if (xs < 0 || xs >= W || ys < 0 || ys >= H) {
+                    obase[y * W + x] = T{0};
+                } else {
+                    obase[y * W + x] = base[ys * W + xs];
+                }
+            }
+        }
+    }
+}
+
+}  // namespace
+
+TensorImplPtr rotate_op(const TensorImplPtr& input, double angle_deg,
+                          double cy, double cx) {
+    if (!input) throw LucidError("rotate: null input");
+    if (input->shape_.size() != 4)
+        throw ShapeMismatch(input->shape_, Shape{},
+                             "rotate: input must be 4-D (N, C, H, W)");
+    const int N = static_cast<int>(input->shape_[0]);
+    const int C = static_cast<int>(input->shape_[1]);
+    const int H = static_cast<int>(input->shape_[2]);
+    const int W = static_cast<int>(input->shape_[3]);
+    OpScope scope{"rotate", input->device_, input->dtype_, input->shape_};
+    const double angle_rad_neg = -angle_deg * (M_PI / 180.0);
+
+    if (input->device_ == Device::GPU) {
+        // GPU: download → CPU compute → upload (nearest-neighbor remap is small).
+        auto x_cpu = gpu::download_gpu_to_cpu(
+            std::get<GpuStorage>(input->storage_), input->shape_);
+        auto out_cpu = allocate_size(static_cast<std::size_t>(N) * C * H * W,
+                                       input->dtype_);
+        if (input->dtype_ == Dtype::F32)
+            rotate_cpu_kernel<float>(
+                reinterpret_cast<const float*>(x_cpu.ptr.get()),
+                reinterpret_cast<float*>(out_cpu.ptr.get()),
+                N, C, H, W, angle_rad_neg, cx, cy);
+        else if (input->dtype_ == Dtype::F64)
+            rotate_cpu_kernel<double>(
+                reinterpret_cast<const double*>(x_cpu.ptr.get()),
+                reinterpret_cast<double*>(out_cpu.ptr.get()),
+                N, C, H, W, angle_rad_neg, cx, cy);
+        else
+            throw NotImplementedError("rotate: dtype must be F32/F64");
+        return std::make_shared<TensorImpl>(
+            Storage{gpu::upload_cpu_to_gpu(out_cpu, input->shape_)},
+            input->shape_, input->dtype_, input->device_, false);
+    }
+    auto out_cpu = allocate_size(static_cast<std::size_t>(N) * C * H * W,
+                                   input->dtype_);
+    const auto& xs = std::get<CpuStorage>(input->storage_);
+    if (input->dtype_ == Dtype::F32)
+        rotate_cpu_kernel<float>(
+            reinterpret_cast<const float*>(xs.ptr.get()),
+            reinterpret_cast<float*>(out_cpu.ptr.get()),
+            N, C, H, W, angle_rad_neg, cx, cy);
+    else if (input->dtype_ == Dtype::F64)
+        rotate_cpu_kernel<double>(
+            reinterpret_cast<const double*>(xs.ptr.get()),
+            reinterpret_cast<double*>(out_cpu.ptr.get()),
+            N, C, H, W, angle_rad_neg, cx, cy);
+    else
+        throw NotImplementedError("rotate: dtype must be F32/F64");
+    return std::make_shared<TensorImpl>(Storage{std::move(out_cpu)},
+                                         input->shape_, input->dtype_,
+                                         input->device_, false);
+}
+
+// =====================================================================
+// bilinear (learned bilinear layer): y[..., k] = x1 W_k x2 + b_k
+// =====================================================================
+//
+// x1: [..., D1]   x2: [..., D2]   weight: [Dout, D1, D2]   bias: [Dout]
+// Forward:
+//   tmp = einsum("...i, k i j -> ...k j", x1, W)            # [..., Dout, D2]
+//   y   = einsum("...k j, ...j -> ...k", tmp, x2) + bias    # [..., Dout]
+// Backward (broadcast over batch dims; we collapse leading dims to a single B):
+//   dx1[k]  = sum_k dY[..., k] · W[k, :, :] · x2
+//   dx2[j]  = sum_k dY[..., k] · W[k, i, :]^T · x1[i] (per-element); explicit form below.
+//   dW[k,i,j] = sum_batch dY[..., k] · x1[i] · x2[j]
+//   db[k]   = sum_batch dY[..., k]
+
+const OpSchema BilinearLayerBackward::schema_v1{
+    "bilinear_layer", 1, AmpPolicy::Promote, true};
+
+namespace {
+
+struct BilinearShape {
+    std::size_t B;
+    std::size_t D1;
+    std::size_t D2;
+    std::size_t Dout;
+};
+
+BilinearShape flatten_bilinear(const Shape& s1, const Shape& s2,
+                                const Shape& sw) {
+    if (s1.empty() || s2.empty()) {
+        throw LucidError("bilinear: input must have ≥1 dim");
+    }
+    if (sw.size() != 3) {
+        throw ShapeMismatch(sw, Shape{}, "bilinear: weight must be 3-D");
+    }
+    if (s1.size() != s2.size()) {
+        throw ShapeMismatch(s1, s2, "bilinear: x1/x2 must have same rank");
+    }
+    BilinearShape r;
+    r.Dout = static_cast<std::size_t>(sw[0]);
+    r.D1   = static_cast<std::size_t>(sw[1]);
+    r.D2   = static_cast<std::size_t>(sw[2]);
+    if (static_cast<std::size_t>(s1.back()) != r.D1
+        || static_cast<std::size_t>(s2.back()) != r.D2) {
+        throw ShapeMismatch(s1, sw, "bilinear: last dims must match weight");
+    }
+    std::size_t b = 1;
+    for (std::size_t i = 0; i + 1 < s1.size(); ++i) {
+        if (s1[i] != s2[i])
+            throw ShapeMismatch(s1, s2, "bilinear: batch dims must match");
+        b *= static_cast<std::size_t>(s1[i]);
+    }
+    r.B = b;
+    return r;
+}
+
+template <typename T>
+void bilinear_forward_cpu(const T* x1, const T* x2, const T* W, const T* b,
+                            T* y, std::size_t B, std::size_t D1, std::size_t D2,
+                            std::size_t Dout) {
+    for (std::size_t bi = 0; bi < B; ++bi) {
+        const T* x1b = x1 + bi * D1;
+        const T* x2b = x2 + bi * D2;
+        T* yb = y + bi * Dout;
+        for (std::size_t k = 0; k < Dout; ++k) {
+            const T* Wk = W + k * D1 * D2;
+            T acc = T{0};
+            for (std::size_t i = 0; i < D1; ++i) {
+                T row_acc = T{0};
+                for (std::size_t j = 0; j < D2; ++j) {
+                    row_acc += Wk[i * D2 + j] * x2b[j];
+                }
+                acc += x1b[i] * row_acc;
+            }
+            yb[k] = acc + (b ? b[k] : T{0});
+        }
+    }
+}
+
+template <typename T>
+void bilinear_backward_cpu(const T* x1, const T* x2, const T* W, const T* gy,
+                             T* dx1, T* dx2, T* dW, T* db,
+                             std::size_t B, std::size_t D1, std::size_t D2,
+                             std::size_t Dout, bool need_db) {
+    std::memset(dx1, 0, sizeof(T) * B * D1);
+    std::memset(dx2, 0, sizeof(T) * B * D2);
+    std::memset(dW,  0, sizeof(T) * Dout * D1 * D2);
+    if (db) std::memset(db, 0, sizeof(T) * Dout);
+    (void)need_db;
+    for (std::size_t bi = 0; bi < B; ++bi) {
+        const T* x1b = x1 + bi * D1;
+        const T* x2b = x2 + bi * D2;
+        const T* gb = gy + bi * Dout;
+        T* dx1b = dx1 + bi * D1;
+        T* dx2b = dx2 + bi * D2;
+        for (std::size_t k = 0; k < Dout; ++k) {
+            const T g = gb[k];
+            if (db) db[k] += g;
+            const T* Wk = W + k * D1 * D2;
+            T* dWk = dW + k * D1 * D2;
+            for (std::size_t i = 0; i < D1; ++i) {
+                const T x1_i = x1b[i];
+                T row_acc = T{0};
+                for (std::size_t j = 0; j < D2; ++j) {
+                    const T w_ij = Wk[i * D2 + j];
+                    row_acc += w_ij * x2b[j];
+                    dx2b[j] += g * x1_i * w_ij;
+                    dWk[i * D2 + j] += g * x1_i * x2b[j];
+                }
+                dx1b[i] += g * row_acc;
+            }
+        }
+    }
+}
+
+}  // namespace
+
+TensorImplPtr BilinearLayerBackward::forward(const TensorImplPtr& x1,
+                                              const TensorImplPtr& x2,
+                                              const TensorImplPtr& weight,
+                                              const TensorImplPtr& bias) {
+    if (!x1 || !x2 || !weight)
+        throw LucidError("bilinear_layer: null input");
+    if (x1->dtype_ != x2->dtype_ || x1->dtype_ != weight->dtype_)
+        throw DtypeMismatch(std::string(dtype_name(x1->dtype_)),
+                            std::string(dtype_name(x2->dtype_)),
+                            "bilinear_layer");
+    if (x1->device_ != x2->device_ || x1->device_ != weight->device_)
+        throw DeviceMismatch(std::string(device_name(x1->device_)),
+                              std::string(device_name(x2->device_)),
+                              "bilinear_layer");
+    const auto bs = flatten_bilinear(x1->shape_, x2->shape_, weight->shape_);
+    Shape out_shape = x1->shape_;
+    out_shape.back() = static_cast<std::int64_t>(bs.Dout);
+    OpScope scope{schema_v1.name, x1->device_, x1->dtype_, out_shape};
+
+    Storage out_storage;
+    if (x1->device_ == Device::GPU) {
+        const auto& gx1 = std::get<GpuStorage>(x1->storage_);
+        const auto& gx2 = std::get<GpuStorage>(x2->storage_);
+        const auto& gw  = std::get<GpuStorage>(weight->storage_);
+        const auto mlx_dt = gpu::to_mlx_dtype(x1->dtype_);
+        // Reshape inputs: x1 → [B, D1], x2 → [B, D2], W → [Dout, D1, D2].
+        auto x1_b = ::mlx::core::reshape(*gx1.arr,
+            {static_cast<int>(bs.B), static_cast<int>(bs.D1)});
+        auto x2_b = ::mlx::core::reshape(*gx2.arr,
+            {static_cast<int>(bs.B), static_cast<int>(bs.D2)});
+        // tmp[b, k, j] = sum_i x1[b, i] * W[k, i, j]
+        // Using batched matmul: treat W as [Dout, D1, D2] → for each k a [D1, D2].
+        // Easier path: tmp[b, k, j] = (x1[b, :] @ W[k, :, :])[j]
+        // → tmp = einsum("bi, kij -> bkj"). Implement via:
+        //   x1_e[b, 1, i] @ W[k, i, j] → broadcast not directly supported in mlx::matmul.
+        // Use: x1_b [B, D1] @ W reshaped to [D1, Dout*D2] → [B, Dout*D2] → [B, Dout, D2].
+        auto W_rs = ::mlx::core::transpose(*gw.arr, {1, 0, 2});  // [D1, Dout, D2]
+        auto W_rs2 = ::mlx::core::reshape(W_rs,
+            {static_cast<int>(bs.D1), static_cast<int>(bs.Dout * bs.D2)});
+        auto tmp = ::mlx::core::matmul(x1_b, W_rs2);  // [B, Dout*D2]
+        auto tmp_3d = ::mlx::core::reshape(tmp,
+            {static_cast<int>(bs.B), static_cast<int>(bs.Dout),
+              static_cast<int>(bs.D2)});
+        // y[b, k] = sum_j tmp[b, k, j] * x2[b, j]
+        auto x2_e = ::mlx::core::reshape(x2_b,
+            {static_cast<int>(bs.B), static_cast<int>(bs.D2), 1});
+        auto y_e = ::mlx::core::matmul(tmp_3d, x2_e);  // [B, Dout, 1]
+        auto y_2d = ::mlx::core::reshape(y_e,
+            {static_cast<int>(bs.B), static_cast<int>(bs.Dout)});
+        if (bias) {
+            const auto& gb = std::get<GpuStorage>(bias->storage_);
+            y_2d = ::mlx::core::add(y_2d, *gb.arr);
+        }
+        auto y_out = ::mlx::core::reshape(y_2d, gpu::to_mlx_shape(out_shape));
+        out_storage = Storage{gpu::wrap_mlx_array(std::move(y_out), x1->dtype_)};
+    } else {
+        auto out_cpu = allocate_size(bs.B * bs.Dout, x1->dtype_);
+        const auto& xs1 = std::get<CpuStorage>(x1->storage_);
+        const auto& xs2 = std::get<CpuStorage>(x2->storage_);
+        const auto& ws  = std::get<CpuStorage>(weight->storage_);
+        const CpuStorage* bs_ptr = bias ? &std::get<CpuStorage>(bias->storage_) : nullptr;
+        if (x1->dtype_ == Dtype::F32)
+            bilinear_forward_cpu<float>(
+                reinterpret_cast<const float*>(xs1.ptr.get()),
+                reinterpret_cast<const float*>(xs2.ptr.get()),
+                reinterpret_cast<const float*>(ws.ptr.get()),
+                bs_ptr ? reinterpret_cast<const float*>(bs_ptr->ptr.get()) : nullptr,
+                reinterpret_cast<float*>(out_cpu.ptr.get()),
+                bs.B, bs.D1, bs.D2, bs.Dout);
+        else if (x1->dtype_ == Dtype::F64)
+            bilinear_forward_cpu<double>(
+                reinterpret_cast<const double*>(xs1.ptr.get()),
+                reinterpret_cast<const double*>(xs2.ptr.get()),
+                reinterpret_cast<const double*>(ws.ptr.get()),
+                bs_ptr ? reinterpret_cast<const double*>(bs_ptr->ptr.get()) : nullptr,
+                reinterpret_cast<double*>(out_cpu.ptr.get()),
+                bs.B, bs.D1, bs.D2, bs.Dout);
+        else
+            throw NotImplementedError("bilinear_layer: dtype must be F32/F64");
+        out_storage = Storage{std::move(out_cpu)};
+    }
+
+    auto out = std::make_shared<TensorImpl>(std::move(out_storage),
+                                             out_shape, x1->dtype_,
+                                             x1->device_, false);
+    const bool any_grad = x1->requires_grad_ || x2->requires_grad_
+                          || weight->requires_grad_
+                          || (bias && bias->requires_grad_);
+    if (!GradMode::is_enabled() || !any_grad) return out;
+
+    auto x1_edge = detail::ensure_grad_fn(x1);
+    auto x2_edge = detail::ensure_grad_fn(x2);
+    auto w_edge  = detail::ensure_grad_fn(weight);
+    auto b_edge  = bias ? detail::ensure_grad_fn(bias) : std::shared_ptr<Node>();
+    auto bwd = std::make_shared<BilinearLayerBackward>();
+    if (bias) {
+        bwd->input_shapes_ = {x1->shape_, x2->shape_, weight->shape_, bias->shape_};
+        bwd->input_tensors_ = {x1, x2, weight, bias};
+        bwd->saved_inputs_ = {x1->storage_, x2->storage_, weight->storage_,
+                                bias->storage_};
+    } else {
+        // Bias slot is required by FuncOp<4>; store an empty CpuStorage and
+        // a null TensorImplPtr — apply() will detect the empty slot and skip
+        // the db output.
+        bwd->input_shapes_ = {x1->shape_, x2->shape_, weight->shape_, Shape{}};
+        bwd->input_tensors_[0] = x1;
+        bwd->input_tensors_[1] = x2;
+        bwd->input_tensors_[2] = weight;
+        // Slot 3 left default-constructed (empty weak_ptr).
+        CpuStorage empty;
+        empty.dtype = x1->dtype_; empty.nbytes = 0;
+        bwd->saved_inputs_ = {x1->storage_, x2->storage_, weight->storage_,
+                                Storage{std::move(empty)}};
+    }
+    bwd->out_shape_ = out_shape;
+    bwd->dtype_     = x1->dtype_;
+    bwd->device_    = x1->device_;
+    bwd->orig_x1_shape_ = x1->shape_;
+    bwd->orig_x2_shape_ = x2->shape_;
+    std::vector<Edge> edges{Edge(x1_edge, 0), Edge(x2_edge, 0), Edge(w_edge, 0)};
+    if (bias) edges.emplace_back(b_edge, 0);
+    else      edges.emplace_back(std::shared_ptr<Node>(), 0);
+    bwd->set_next_edges(std::move(edges));
+    std::vector<std::int64_t> versions{
+        static_cast<std::int64_t>(x1->version_),
+        static_cast<std::int64_t>(x2->version_),
+        static_cast<std::int64_t>(weight->version_)};
+    if (bias) versions.push_back(static_cast<std::int64_t>(bias->version_));
+    else      versions.push_back(0);
+    bwd->set_saved_versions(std::move(versions));
+    out->grad_fn_ = std::move(bwd);
+    out->is_leaf_ = false;
+    out->requires_grad_ = true;
+    return out;
+}
+
+std::vector<Storage> BilinearLayerBackward::apply(Storage grad_out) {
+    const auto bs = flatten_bilinear(orig_x1_shape_, orig_x2_shape_,
+                                       input_shapes_[2]);
+    const bool has_bias = !input_shapes_[3].empty();
+
+    // Bridge through CPU for both devices to keep autograd analytic + simple.
+    CpuStorage x1_cpu, x2_cpu, w_cpu, b_cpu, gy_cpu;
+    const CpuStorage* x1_ptr;
+    const CpuStorage* x2_ptr;
+    const CpuStorage* w_ptr;
+    const CpuStorage* b_ptr;
+    const CpuStorage* gy_ptr;
+    if (device_ == Device::GPU) {
+        x1_cpu = gpu::download_gpu_to_cpu(std::get<GpuStorage>(saved_inputs_[0]),
+                                            orig_x1_shape_);
+        x2_cpu = gpu::download_gpu_to_cpu(std::get<GpuStorage>(saved_inputs_[1]),
+                                            orig_x2_shape_);
+        w_cpu  = gpu::download_gpu_to_cpu(std::get<GpuStorage>(saved_inputs_[2]),
+                                            input_shapes_[2]);
+        if (has_bias)
+            b_cpu = gpu::download_gpu_to_cpu(
+                std::get<GpuStorage>(saved_inputs_[3]), input_shapes_[3]);
+        gy_cpu = gpu::download_gpu_to_cpu(std::get<GpuStorage>(grad_out),
+                                            out_shape_);
+        x1_ptr = &x1_cpu; x2_ptr = &x2_cpu; w_ptr = &w_cpu;
+        b_ptr = has_bias ? &b_cpu : nullptr;
+        gy_ptr = &gy_cpu;
+    } else {
+        x1_ptr = &std::get<CpuStorage>(saved_inputs_[0]);
+        x2_ptr = &std::get<CpuStorage>(saved_inputs_[1]);
+        w_ptr  = &std::get<CpuStorage>(saved_inputs_[2]);
+        b_ptr  = has_bias ? &std::get<CpuStorage>(saved_inputs_[3]) : nullptr;
+        gy_ptr = &std::get<CpuStorage>(grad_out);
+    }
+
+    auto dx1_cpu = allocate_size(bs.B * bs.D1, dtype_);
+    auto dx2_cpu = allocate_size(bs.B * bs.D2, dtype_);
+    auto dW_cpu  = allocate_size(bs.Dout * bs.D1 * bs.D2, dtype_);
+    auto db_cpu  = has_bias ? allocate_size(bs.Dout, dtype_) : CpuStorage{};
+
+    auto run = [&](auto type_tag) {
+        using T = decltype(type_tag);
+        bilinear_backward_cpu<T>(
+            reinterpret_cast<const T*>(x1_ptr->ptr.get()),
+            reinterpret_cast<const T*>(x2_ptr->ptr.get()),
+            reinterpret_cast<const T*>(w_ptr->ptr.get()),
+            reinterpret_cast<const T*>(gy_ptr->ptr.get()),
+            reinterpret_cast<T*>(dx1_cpu.ptr.get()),
+            reinterpret_cast<T*>(dx2_cpu.ptr.get()),
+            reinterpret_cast<T*>(dW_cpu.ptr.get()),
+            has_bias ? reinterpret_cast<T*>(db_cpu.ptr.get()) : nullptr,
+            bs.B, bs.D1, bs.D2, bs.Dout, has_bias);
+    };
+    if (dtype_ == Dtype::F32) run(float{});
+    else if (dtype_ == Dtype::F64) run(double{});
+    else throw NotImplementedError("bilinear_layer backward: dtype not supported");
+
+    if (device_ == Device::GPU) {
+        std::vector<Storage> out_grads;
+        out_grads.push_back(Storage{gpu::upload_cpu_to_gpu(dx1_cpu, orig_x1_shape_)});
+        out_grads.push_back(Storage{gpu::upload_cpu_to_gpu(dx2_cpu, orig_x2_shape_)});
+        out_grads.push_back(Storage{gpu::upload_cpu_to_gpu(dW_cpu, input_shapes_[2])});
+        if (has_bias)
+            out_grads.push_back(Storage{
+                gpu::upload_cpu_to_gpu(db_cpu, input_shapes_[3])});
+        else {
+            CpuStorage empty;
+            empty.dtype = dtype_; empty.nbytes = 0;
+            out_grads.push_back(Storage{std::move(empty)});
+        }
+        return out_grads;
+    }
+    std::vector<Storage> out_grads;
+    out_grads.push_back(Storage{std::move(dx1_cpu)});
+    out_grads.push_back(Storage{std::move(dx2_cpu)});
+    out_grads.push_back(Storage{std::move(dW_cpu)});
+    if (has_bias) out_grads.push_back(Storage{std::move(db_cpu)});
+    else {
+        CpuStorage empty;
+        empty.dtype = dtype_; empty.nbytes = 0;
+        out_grads.push_back(Storage{std::move(empty)});
+    }
+    return out_grads;
+}
+
+TensorImplPtr bilinear_layer_op(const TensorImplPtr& x1,
+                                  const TensorImplPtr& x2,
+                                  const TensorImplPtr& weight,
+                                  const TensorImplPtr& bias) {
+    return BilinearLayerBackward::forward(x1, x2, weight, bias);
+}
+LUCID_REGISTER_OP(BilinearLayerBackward)
+
+}  // namespace lucid

--- a/lucid/_C/nn/Vision.h
+++ b/lucid/_C/nn/Vision.h
@@ -1,0 +1,51 @@
+#pragma once
+
+// =====================================================================
+// Lucid C++ engine — vision / utility kernels.
+// =====================================================================
+//
+//   one_hot(input, num_classes)
+//     Integer indices → one-hot tensor.  Output shape: input.shape + [C].
+//     No autograd (integer input, output is constant given the index).
+//
+//   rotate(input, angle, cy, cx)
+//     2-D image rotation (N, C, H, W) by `angle` degrees around (cy, cx).
+//     Nearest-neighbor sampling; out-of-bounds → 0.
+//     No autograd (discrete pixel remap).
+//
+//   bilinear_layer(x1, x2, weight, bias)
+//     Learned bilinear layer: y[..., k] = sum_{i,j} x1[i] * weight[k,i,j] *
+//     x2[j] + bias[k].  Forward + backward; differentiable in all inputs.
+
+#include "../api.h"
+#include "../core/AmpPolicy.h"
+#include "../core/OpSchema.h"
+#include "../core/Storage.h"
+#include "../core/fwd.h"
+#include "../autograd/FuncOp.h"
+
+namespace lucid {
+
+class LUCID_API BilinearLayerBackward
+    : public FuncOp<BilinearLayerBackward, 4> {
+public:
+    static const OpSchema schema_v1;
+    Shape orig_x1_shape_;
+    Shape orig_x2_shape_;
+    static TensorImplPtr forward(const TensorImplPtr& x1,
+                                  const TensorImplPtr& x2,
+                                  const TensorImplPtr& weight,
+                                  const TensorImplPtr& bias);
+    std::vector<Storage> apply(Storage grad_out) override;
+};
+
+LUCID_API TensorImplPtr one_hot_op(const TensorImplPtr& input,
+                                     int num_classes, Dtype out_dtype);
+LUCID_API TensorImplPtr rotate_op(const TensorImplPtr& input,
+                                    double angle_deg, double cy, double cx);
+LUCID_API TensorImplPtr bilinear_layer_op(const TensorImplPtr& x1,
+                                            const TensorImplPtr& x2,
+                                            const TensorImplPtr& weight,
+                                            const TensorImplPtr& bias);
+
+}  // namespace lucid

--- a/lucid/nn/functional/_linear.py
+++ b/lucid/nn/functional/_linear.py
@@ -24,16 +24,6 @@ def linear(input_: Tensor, weight: Tensor, bias: Tensor | None = None) -> Tensor
 def bilinear(
     input_1: Tensor, input_2: Tensor, weight: Tensor, bias: Tensor | None = None
 ) -> Tensor:
-    outputs = []
-    for i in range(weight.shape[0]):
-        wi = weight[i]
-        outputs.append(((input_1 @ wi) * input_2).sum(axis=1, keepdims=True))
-
-    if len(outputs) == 1:
-        output = outputs[0]
-    else:
-        output = lucid.concatenate(tuple(outputs), axis=1)
-
-    if bias is not None:
-        output = output + bias
-    return output
+    return Tensor._wrap(_C_nn.bilinear_layer(
+        impl_of(input_1), impl_of(input_2), impl_of(weight),
+        impl_of(bias) if bias is not None else None))

--- a/lucid/nn/functional/_utils.py
+++ b/lucid/nn/functional/_utils.py
@@ -1,179 +1,68 @@
 """
-lucid.nn.functional._utils — interpolation, rotate, one_hot.
+lucid.nn.functional._utils — interpolate / rotate / one_hot.
 
-Pure Python composition over engine ops; no engine kernels needed.
+All routes are 1:1 to fused C++ kernels in `_C_nn`. The legacy Python
+compositions are gone; the only remaining Python helper is `area` mode
+of `interpolate`, which is a thin wrapper over `avg_pool2d` (still a
+single C++ op call, no numpy fallback).
 """
 
 from __future__ import annotations
 
-import lucid
-
+from lucid._C.engine import nn as _C_nn
 from lucid._tensor import Tensor
-from lucid.types import _Scalar, Numeric
+from lucid._bridge import impl_of, to_engine_dtype
+from lucid.types import Numeric, _Scalar
 
 
 # --------------------------------------------------------------------------- #
-# Interpolation
+# Interpolate (4 modes)
 # --------------------------------------------------------------------------- #
 
 def _interpolate_bilinear(
     input_: Tensor, size: tuple[int, int], align_corners: bool = False
 ) -> Tensor:
-    _, _, H, W = input_.shape
-    out_h, out_w = size
-    if (H, W) == (out_h, out_w):
-        return input_
-    device = input_.device
-
-    if align_corners:
-        if out_h == 1:
-            indices_h = lucid.zeros((out_h,), dtype=lucid.Float32, device=device)
-        else:
-            indices_h = (lucid.arange(out_h, dtype=lucid.Float32, device=device)
-                         * (H - 1) / (out_h - 1))
-        if out_w == 1:
-            indices_w = lucid.zeros((out_w,), dtype=lucid.Float32, device=device)
-        else:
-            indices_w = (lucid.arange(out_w, dtype=lucid.Float32, device=device)
-                         * (W - 1) / (out_w - 1))
-    else:
-        scale_h = H / out_h
-        scale_w = W / out_w
-        indices_h = (lucid.arange(out_h, dtype=lucid.Float32, device=device)
-                     + 0.5) * scale_h - 0.5
-        indices_w = (lucid.arange(out_w, dtype=lucid.Float32, device=device)
-                     + 0.5) * scale_w - 0.5
-
-    indices_h = indices_h.clip(0, H - 1)
-    indices_w = indices_w.clip(0, W - 1)
-
-    top_indices_f = lucid.floor(indices_h)
-    left_indices_f = lucid.floor(indices_w)
-    top_indices = top_indices_f.astype(lucid.Int)
-    bot_indices = (top_indices_f + 1).clip(0, H - 1).astype(lucid.Int)
-    left_indices = left_indices_f.astype(lucid.Int)
-    right_indices = (left_indices_f + 1).clip(0, W - 1).astype(lucid.Int)
-
-    h_lerp = indices_h - top_indices_f
-    w_lerp = indices_w - left_indices_f
-
-    top_left = input_[:, :, top_indices[:, None], left_indices]
-    top_right = input_[:, :, top_indices[:, None], right_indices]
-    bot_left = input_[:, :, bot_indices[:, None], left_indices]
-    bot_right = input_[:, :, bot_indices[:, None], right_indices]
-
-    top = top_left * (1 - w_lerp) + top_right * w_lerp
-    bot = bot_left * (1 - w_lerp) + bot_right * w_lerp
-    return top * (1 - h_lerp[:, None]) + bot * h_lerp[:, None]
+    H_out, W_out = size
+    return Tensor._wrap(_C_nn.interpolate_bilinear(
+        impl_of(input_), int(H_out), int(W_out), bool(align_corners)))
 
 
 def _interpolate_trilinear(
     input_: Tensor, size: tuple[int, int, int], align_corners: bool = False
 ) -> Tensor:
-    _, _, D, H, W = input_.shape
-    out_d, out_h, out_w = size
-    if (D, H, W) == (out_d, out_h, out_w):
-        return input_
-    device = input_.device
-
-    def _idx(out_n, in_n, ac):
-        if ac:
-            if out_n == 1:
-                return lucid.zeros((out_n,), dtype=lucid.Float32, device=device)
-            return (lucid.arange(out_n, dtype=lucid.Float32, device=device)
-                    * (in_n - 1) / (out_n - 1))
-        return (lucid.arange(out_n, dtype=lucid.Float32, device=device)
-                + 0.5) * (in_n / out_n) - 0.5
-
-    indices_d = _idx(out_d, D, align_corners).clip(0, D - 1)
-    indices_h = _idx(out_h, H, align_corners).clip(0, H - 1)
-    indices_w = _idx(out_w, W, align_corners).clip(0, W - 1)
-
-    d0_f = lucid.floor(indices_d)
-    h0_f = lucid.floor(indices_h)
-    w0_f = lucid.floor(indices_w)
-
-    d0 = d0_f.astype(lucid.Int)
-    d1 = (d0_f + 1).clip(0, D - 1).astype(lucid.Int)
-    h0 = h0_f.astype(lucid.Int)
-    h1 = (h0_f + 1).clip(0, H - 1).astype(lucid.Int)
-    w0 = w0_f.astype(lucid.Int)
-    w1 = (w0_f + 1).clip(0, W - 1).astype(lucid.Int)
-
-    d_lerp = indices_d - d0_f
-    h_lerp = indices_h - h0_f
-    w_lerp = indices_w - w0_f
-
-    c000 = input_[:, :, d0[:, None, None], h0[None, :, None], w0[None, None, :]]
-    c001 = input_[:, :, d0[:, None, None], h0[None, :, None], w1[None, None, :]]
-    c010 = input_[:, :, d0[:, None, None], h1[None, :, None], w0[None, None, :]]
-    c011 = input_[:, :, d0[:, None, None], h1[None, :, None], w1[None, None, :]]
-    c100 = input_[:, :, d1[:, None, None], h0[None, :, None], w0[None, None, :]]
-    c101 = input_[:, :, d1[:, None, None], h0[None, :, None], w1[None, None, :]]
-    c110 = input_[:, :, d1[:, None, None], h1[None, :, None], w0[None, None, :]]
-    c111 = input_[:, :, d1[:, None, None], h1[None, :, None], w1[None, None, :]]
-
-    c00 = c000 * (1 - w_lerp) + c001 * w_lerp
-    c01 = c010 * (1 - w_lerp) + c011 * w_lerp
-    c10 = c100 * (1 - w_lerp) + c101 * w_lerp
-    c11 = c110 * (1 - w_lerp) + c111 * w_lerp
-    c0 = c00 * (1 - h_lerp[:, None]) + c01 * h_lerp[:, None]
-    c1 = c10 * (1 - h_lerp[:, None]) + c11 * h_lerp[:, None]
-    return c0 * (1 - d_lerp[:, None, None]) + c1 * d_lerp[:, None, None]
-
-
-def _interpolate_nearest_3d(
-    input_: Tensor, size: tuple[int, int, int], align_corners: bool = False
-) -> Tensor:
-    _, _, D, H, W = input_.shape
-    out_d, out_h, out_w = size
-    if (D, H, W) == (out_d, out_h, out_w):
-        return input_
-    device = input_.device
-
-    def _idx(out_n, in_n):
-        return (lucid.floor(
-            lucid.arange(out_n, dtype=lucid.Float32, device=device)
-            * (in_n / out_n))
-            .clip(0, in_n - 1).astype(lucid.Int32))
-
-    return input_[:, :,
-                  _idx(out_d, D)[:, None, None],
-                  _idx(out_h, H)[None, :, None],
-                  _idx(out_w, W)[None, None, :]]
+    D_out, H_out, W_out = size
+    return Tensor._wrap(_C_nn.interpolate_trilinear(
+        impl_of(input_), int(D_out), int(H_out), int(W_out),
+        bool(align_corners)))
 
 
 def _interpolate_nearest(
     input_: Tensor, size: tuple[int, int], align_corners: bool = False
 ) -> Tensor:
-    _, _, H, W = input_.shape
-    out_h, out_w = size
-    if (H, W) == (out_h, out_w):
-        return input_
-    device = input_.device
-    scale_h = H / out_h
-    scale_w = W / out_w
-    indices_h = lucid.floor(
-        lucid.arange(out_h, dtype=lucid.Float32, device=device) * scale_h
-    ).clip(0, H - 1).astype(lucid.Int32)
-    indices_w = lucid.floor(
-        lucid.arange(out_w, dtype=lucid.Float32, device=device) * scale_w
-    ).clip(0, W - 1).astype(lucid.Int32)
-    return input_[:, :, indices_h[:, None], indices_w[None, :]]
+    # align_corners has no effect for nearest in PyTorch semantics.
+    H_out, W_out = size
+    return Tensor._wrap(_C_nn.interpolate_nearest_2d(
+        impl_of(input_), int(H_out), int(W_out)))
+
+
+def _interpolate_nearest_3d(
+    input_: Tensor, size: tuple[int, int, int], align_corners: bool = False
+) -> Tensor:
+    D_out, H_out, W_out = size
+    return Tensor._wrap(_C_nn.interpolate_nearest_3d(
+        impl_of(input_), int(D_out), int(H_out), int(W_out)))
 
 
 def _interpolate_area(
     input_: Tensor, size: tuple[int, int], align_corners: bool = False
 ) -> Tensor:
+    # area mode === avg_pool with stride=kernel=floor(in/out). PyTorch parity.
+    from lucid.nn import functional as F
     _, _, H, W = input_.shape
     out_h, out_w = size
-    scale_h = H / out_h
-    scale_w = W / out_w
-    pooled = lucid.nn.functional.avg_pool2d(
-        input_,
-        kernel_size=(int(scale_h), int(scale_w)),
-        stride=(int(scale_h), int(scale_w)),
-    )
+    kh = max(int(H // out_h), 1)
+    kw = max(int(W // out_w), 1)
+    pooled = F.avg_pool2d(input_, kernel_size=(kh, kw), stride=(kh, kw))
     return pooled[:, :, :out_h, :out_w]
 
 
@@ -184,39 +73,15 @@ def _interpolate_area(
 def rotate(
     input_: Tensor, angle: float, center: tuple[_Scalar, _Scalar] | None = None
 ) -> Tensor:
-    import math
-    N, C, H, W = input_.shape
+    if input_.ndim != 4:
+        raise ValueError("rotate: input must be 4-D (N, C, H, W)")
+    _, _, H, W = input_.shape
     if center is None:
-        center_x = W / 2
-        center_y = H / 2
+        cy, cx = H / 2.0, W / 2.0
     else:
-        center_x, center_y = center
-
-    angle_rad = -angle * (math.pi / 180.0)
-    cos_a = math.cos(angle_rad)
-    sin_a = math.sin(angle_rad)
-
-    rot_mat = lucid.Tensor([
-        [cos_a, -sin_a, center_x - cos_a * center_x + sin_a * center_y],
-        [sin_a, cos_a, center_y - sin_a * center_x - cos_a * center_y],
-    ])
-
-    y_coords = lucid.arange(H)
-    x_coords = lucid.arange(W)
-    y_grid, x_grid = lucid.meshgrid(y_coords, x_coords, indexing="ij")
-    x_flat = x_grid.ravel()
-    y_flat = y_grid.ravel()
-    ones = lucid.ones_like(x_flat)
-    homogen = lucid.stack([x_flat, y_flat, ones])
-    new_coords = rot_mat @ homogen
-    new_x = new_coords[0].reshape(H, W).clip(0, W - 1).astype(lucid.Int)
-    new_y = new_coords[1].reshape(H, W).clip(0, H - 1).astype(lucid.Int)
-
-    rotated = lucid.zeros_like(input_, device=input_.device)
-    for n in range(N):
-        for c in range(C):
-            rotated[n, c] = input_[n, c, new_y, new_x]
-    return rotated
+        cx, cy = float(center[0]), float(center[1])
+    return Tensor._wrap(_C_nn.rotate(
+        impl_of(input_), float(angle), float(cy), float(cx)))
 
 
 # --------------------------------------------------------------------------- #
@@ -229,13 +94,11 @@ def one_hot(
     if input_.dtype.base_dtype is not int:
         raise TypeError("one_hot only supports integer input.")
     if num_classes == -1:
+        # Best-effort: infer from data.  Materializes once on host.
+        import lucid
         num_classes = int(lucid.max(input_).item()) + 1
-
-    flat = input_.reshape(-1)
-    N = flat.shape[0]
-    out_shape = (*input_.shape, num_classes)
-    out = lucid.zeros(N, num_classes, device=input_.device, dtype=lucid.Int8)
-    arange = lucid.arange(N, device=input_.device, dtype=lucid.Int32)
-    out[arange, flat.astype(lucid.Int)] = 1
-    return (out.reshape(out_shape).astype(dtype) if dtype is not None
-            else out.reshape(out_shape))
+    from lucid.types import Int8
+    out_dtype = dtype if dtype is not None else Int8
+    eng_dt = to_engine_dtype(out_dtype)
+    return Tensor._wrap(_C_nn.one_hot(
+        impl_of(input_), int(num_classes), eng_dt))

--- a/scripts/verify_phase6_9.py
+++ b/scripts/verify_phase6_9.py
@@ -1,0 +1,222 @@
+"""Phase 6-9 verifier: interpolate / one_hot / rotate / bilinear (CPU+GPU)."""
+
+from __future__ import annotations
+
+import math
+import numpy as np
+
+import lucid
+from lucid._tensor import Tensor
+from lucid._C import engine as _E
+from lucid.ops.bfunc import multiply
+from lucid.ops.ufunc import sum as sum_op
+import lucid.nn.functional as F
+
+
+def gpu_t(arr: np.ndarray, requires_grad: bool = False) -> Tensor:
+    return Tensor._wrap(_E.TensorImpl(arr, _E.Device.GPU, requires_grad))
+
+
+_pass = 0
+_fail = 0
+
+
+def _check(name: str, ok: bool, detail: str = "") -> None:
+    global _pass, _fail
+    tag = "PASS " if ok else "FAIL "
+    if ok:
+        _pass += 1
+    else:
+        _fail += 1
+    print(f"  {tag}  {name}: {detail}")
+
+
+# --------------------------------------------------------------------- #
+# interpolate (bilinear)
+# --------------------------------------------------------------------- #
+print("=== interpolate bilinear ===")
+np.random.seed(0)
+xn = np.random.randn(2, 3, 5, 7).astype(np.float32)
+gout = np.random.randn(2, 3, 4, 6).astype(np.float32)
+for align in (False, True):
+    xc = Tensor(xn, requires_grad=True); xg = gpu_t(xn, True)
+    oc = F.interpolate(xc, (4, 6), mode="bilinear", align_corners=align)
+    og = F.interpolate(xg, (4, 6), mode="bilinear", align_corners=align)
+    sum_op(multiply(oc, Tensor(gout))).backward()
+    sum_op(multiply(og, gpu_t(gout))).backward()
+    err_fwd = np.abs(oc.data - og.data).max()
+    err_grad = np.abs(xc.grad - xg.grad).max()
+    _check(f"bilinear align={align} fwd",
+           err_fwd < 1e-4, f"err={err_fwd:.2e}")
+    _check(f"bilinear align={align} dx",
+           err_grad < 1e-4, f"err={err_grad:.2e}")
+
+# Reference vs PyTorch-like formula (CPU only)
+def ref_bilinear(x, H_out, W_out, align):
+    N, C, H, W = x.shape
+    if align:
+        ys = np.linspace(0, H - 1, H_out, dtype=np.float32) if H_out > 1 else np.zeros(H_out, np.float32)
+        xs = np.linspace(0, W - 1, W_out, dtype=np.float32) if W_out > 1 else np.zeros(W_out, np.float32)
+    else:
+        ys = (np.arange(H_out, dtype=np.float32) + 0.5) * H / H_out - 0.5
+        xs = (np.arange(W_out, dtype=np.float32) + 0.5) * W / W_out - 0.5
+    ys = np.clip(ys, 0, H - 1)
+    xs = np.clip(xs, 0, W - 1)
+    out = np.zeros((N, C, H_out, W_out), np.float32)
+    for h, iy in enumerate(ys):
+        y0 = int(np.floor(iy)); y1 = min(y0 + 1, H - 1); dy = iy - y0
+        for w, ix in enumerate(xs):
+            x0 = int(np.floor(ix)); x1 = min(x0 + 1, W - 1); dx = ix - x0
+            out[:, :, h, w] = (
+                x[:, :, y0, x0] * (1 - dy) * (1 - dx)
+              + x[:, :, y0, x1] * (1 - dy) * dx
+              + x[:, :, y1, x0] * dy * (1 - dx)
+              + x[:, :, y1, x1] * dy * dx
+            )
+    return out
+
+for align in (False, True):
+    ref = ref_bilinear(xn, 4, 6, align)
+    out = F.interpolate(Tensor(xn), (4, 6), mode="bilinear", align_corners=align)
+    err = np.abs(out.data - ref).max()
+    _check(f"bilinear align={align} vs ref", err < 1e-5, f"err={err:.2e}")
+
+# --------------------------------------------------------------------- #
+# interpolate (trilinear, 5-D)
+# --------------------------------------------------------------------- #
+print("\n=== interpolate trilinear ===")
+xn5 = np.random.randn(1, 2, 3, 4, 5).astype(np.float32)
+gout5 = np.random.randn(1, 2, 2, 3, 4).astype(np.float32)
+for align in (False, True):
+    xc = Tensor(xn5, requires_grad=True); xg = gpu_t(xn5, True)
+    oc = F.interpolate(xc, (2, 3, 4), mode="trilinear", align_corners=align)
+    og = F.interpolate(xg, (2, 3, 4), mode="trilinear", align_corners=align)
+    sum_op(multiply(oc, Tensor(gout5))).backward()
+    sum_op(multiply(og, gpu_t(gout5))).backward()
+    _check(f"trilinear align={align} fwd",
+           np.allclose(oc.data, og.data, atol=1e-4),
+           f"max_err={np.abs(oc.data - og.data).max():.2e}")
+    _check(f"trilinear align={align} dx",
+           np.allclose(xc.grad, xg.grad, atol=1e-4),
+           f"max_err={np.abs(xc.grad - xg.grad).max():.2e}")
+
+# --------------------------------------------------------------------- #
+# interpolate (nearest 4-D and 5-D)
+# --------------------------------------------------------------------- #
+print("\n=== interpolate nearest ===")
+xc = Tensor(xn); xg = gpu_t(xn)
+oc = F.interpolate(xc, (4, 6), mode="nearest")
+og = F.interpolate(xg, (4, 6), mode="nearest")
+_check("nearest 4-D match",
+       np.allclose(oc.data, og.data, atol=0),
+       f"max_err={np.abs(oc.data - og.data).max():.2e}")
+
+xc5 = Tensor(xn5); xg5 = gpu_t(xn5)
+oc = F.interpolate(xc5, (2, 3, 4), mode="nearest")
+og = F.interpolate(xg5, (2, 3, 4), mode="nearest")
+_check("nearest 5-D match",
+       np.allclose(oc.data, og.data, atol=0),
+       f"max_err={np.abs(oc.data - og.data).max():.2e}")
+
+# --------------------------------------------------------------------- #
+# one_hot
+# --------------------------------------------------------------------- #
+print("\n=== one_hot ===")
+ix = np.array([[0, 1, 2], [3, 1, 0]], dtype=np.int64)
+oc = F.one_hot(Tensor(ix), num_classes=4)
+og = F.one_hot(gpu_t(ix), num_classes=4)
+ref = np.eye(4, dtype=np.int8)[ix]
+_check("one_hot CPU value", np.allclose(oc.data, ref, atol=0),
+       f"shape={oc.shape}")
+_check("one_hot GPU vs CPU", np.allclose(np.array(oc.data), np.array(og.data), atol=0),
+       f"shape={og.shape}")
+
+# float dtype
+from lucid.types import Float32
+oc_f = F.one_hot(Tensor(ix), num_classes=4, dtype=Float32)
+_check("one_hot float dtype", oc_f.dtype is Float32, "")
+
+# --------------------------------------------------------------------- #
+# rotate
+# --------------------------------------------------------------------- #
+print("\n=== rotate ===")
+img = np.random.randn(1, 1, 5, 5).astype(np.float32)
+oc = F.rotate(Tensor(img), 0.0)
+_check("rotate 0° identity",
+       np.allclose(oc.data, img, atol=0),
+       f"max_err={np.abs(oc.data - img).max():.2e}")
+
+# 90° rotation should map (h, w) → (w, H-1-h)
+oc = F.rotate(Tensor(img), 90.0)
+og = F.rotate(gpu_t(img), 90.0)
+_check("rotate 90° CPU/GPU match",
+       np.allclose(oc.data, og.data, atol=0),
+       f"max_err={np.abs(oc.data - og.data).max():.2e}")
+
+# --------------------------------------------------------------------- #
+# bilinear layer
+# --------------------------------------------------------------------- #
+print("\n=== bilinear layer ===")
+np.random.seed(7)
+B, D1, D2, Dout = 4, 3, 5, 6
+x1 = np.random.randn(B, D1).astype(np.float32)
+x2 = np.random.randn(B, D2).astype(np.float32)
+W = np.random.randn(Dout, D1, D2).astype(np.float32)
+b = np.random.randn(Dout).astype(np.float32)
+gout_b = np.random.randn(B, Dout).astype(np.float32)
+
+# Reference (numpy einsum)
+ref = np.einsum("bi,kij,bj->bk", x1, W, x2) + b
+
+# CPU
+x1c = Tensor(x1, requires_grad=True); x2c = Tensor(x2, requires_grad=True)
+Wc = Tensor(W, requires_grad=True); bc_ = Tensor(b, requires_grad=True)
+oc = F.bilinear(x1c, x2c, Wc, bc_)
+err_fwd = np.abs(oc.data - ref).max()
+_check("bilinear fwd CPU vs ref", err_fwd < 1e-4, f"err={err_fwd:.2e}")
+sum_op(multiply(oc, Tensor(gout_b))).backward()
+
+# Reference grads
+dref_W = np.einsum("bk,bi,bj->kij", gout_b, x1, x2)
+dref_x1 = np.einsum("bk,kij,bj->bi", gout_b, W, x2)
+dref_x2 = np.einsum("bk,kij,bi->bj", gout_b, W, x1)
+dref_b = gout_b.sum(axis=0)
+_check("bilinear dx1 CPU", np.allclose(x1c.grad, dref_x1, atol=1e-4),
+       f"err={np.abs(x1c.grad - dref_x1).max():.2e}")
+_check("bilinear dx2 CPU", np.allclose(x2c.grad, dref_x2, atol=1e-4),
+       f"err={np.abs(x2c.grad - dref_x2).max():.2e}")
+_check("bilinear dW CPU", np.allclose(Wc.grad, dref_W, atol=1e-4),
+       f"err={np.abs(Wc.grad - dref_W).max():.2e}")
+_check("bilinear db CPU", np.allclose(bc_.grad, dref_b, atol=1e-4),
+       f"err={np.abs(bc_.grad - dref_b).max():.2e}")
+
+# GPU
+x1g = gpu_t(x1, True); x2g = gpu_t(x2, True)
+Wg = gpu_t(W, True); bg = gpu_t(b, True)
+og = F.bilinear(x1g, x2g, Wg, bg)
+sum_op(multiply(og, gpu_t(gout_b))).backward()
+_check("bilinear fwd GPU vs CPU",
+       np.allclose(og.data, oc.data, atol=1e-4),
+       f"err={np.abs(og.data - oc.data).max():.2e}")
+_check("bilinear dx1 GPU", np.allclose(x1g.grad, dref_x1, atol=1e-4), "")
+_check("bilinear dW GPU", np.allclose(Wg.grad, dref_W, atol=1e-4), "")
+_check("bilinear db GPU", np.allclose(bg.grad, dref_b, atol=1e-4), "")
+
+# Multi-dim batch (..., D1) / (..., D2)
+x1nd = np.random.randn(2, 3, D1).astype(np.float32)
+x2nd = np.random.randn(2, 3, D2).astype(np.float32)
+gnd = np.random.randn(2, 3, Dout).astype(np.float32)
+ref_nd = np.einsum("bsi,kij,bsj->bsk", x1nd, W, x2nd) + b
+xc1 = Tensor(x1nd, requires_grad=True); xc2 = Tensor(x2nd, requires_grad=True)
+Wc2 = Tensor(W, requires_grad=True); bc2 = Tensor(b, requires_grad=True)
+oc_nd = F.bilinear(xc1, xc2, Wc2, bc2)
+_check("bilinear N-D fwd", np.allclose(oc_nd.data, ref_nd, atol=1e-4),
+       f"err={np.abs(oc_nd.data - ref_nd).max():.2e}")
+sum_op(multiply(oc_nd, Tensor(gnd))).backward()
+dref_nd_W = np.einsum("bsk,bsi,bsj->kij", gnd, x1nd, x2nd)
+_check("bilinear N-D dW", np.allclose(Wc2.grad, dref_nd_W, atol=1e-4), "")
+
+# --------------------------------------------------------------------- #
+print(f"\n--- TOTAL: {_pass} passed, {_fail} failed ---")
+import sys
+sys.exit(0 if _fail == 0 else 1)


### PR DESCRIPTION
## Summary

Replaces the four remaining `nn.functional._utils` Python compositions with fused C++ kernels that run on both CPU and GPU. Also drops the Python `for k in range(Dout)` loop in `nn.functional.bilinear` in favour of a single `BilinearLayerBackward` op.

## What changed

### New C++ kernels
| File | Op | Forward | Backward |
|------|-----|--------|---------|
| `nn/Interpolate.{h,cpp}` | `InterpolateBilinearBackward` | CPU + GPU (MLX flat-gather) | CPU; GPU bridges through CPU |
| `nn/Interpolate.{h,cpp}` | `InterpolateTrilinearBackward` | CPU; GPU bridges | CPU; GPU bridges |
| `nn/Interpolate.{h,cpp}` | `interpolate_nearest_2d_op` / `_3d_op` | CPU + GPU (2-D); CPU bridge (3-D) | n/a (no autograd) |
| `nn/Vision.{h,cpp}` | `one_hot_op` | CPU + GPU (MLX equality + cast) | n/a |
| `nn/Vision.{h,cpp}` | `rotate_op` | CPU + GPU bridge | n/a |
| `nn/Vision.{h,cpp}` | `BilinearLayerBackward` | CPU + GPU (fused batched matmul) | CPU; GPU bridges |

### Python layer
- `nn/functional/_utils.py` shrinks from 240 lines of numpy-style composition to 90 lines of 1:1 wrappers; the only remaining helper is `area` mode of `interpolate`, which is a thin `avg_pool2d` call (already C++).
- `nn/functional/_linear.py::bilinear` becomes a one-liner over `_C_nn.bilinear_layer`.

### Build hygiene
- `.gitignore` now excludes `build/`, `*.egg-info/`, and `phase0_baseline.txt`.

### Bridge-through-CPU paths
Following the precedent set in PR #38 for `grid_sample` backward, this PR keeps the more involved scatter/remap kernels (trilinear, nearest 3-D, rotate, bilinear-layer backward, bilinear-interp backward) as bridge-through-CPU on GPU. They're functional on GPU tensors today; native MLX scatter is a follow-up optimisation.

## Verification

`python3.14 scripts/verify_phase6_9.py` — **28 / 28 passing**:

- Bilinear interpolate: 6 (align_corners True/False, fwd+bwd CPU↔GPU, ref formula)
- Trilinear interpolate: 4 (align_corners True/False, fwd+bwd CPU↔GPU)
- Nearest interpolate: 2 (4-D + 5-D CPU↔GPU)
- one_hot: 3 (CPU value, CPU↔GPU, custom dtype)
- rotate: 2 (0° identity, 90° CPU↔GPU parity)
- bilinear layer: 11 (CPU+GPU forward+backward vs numpy einsum; N-D batch)

## Test plan
- [ ] `python3.14 setup.py build_ext --inplace` builds clean
- [ ] `python3.14 scripts/verify_phase6_9.py` reports 28/28
- [ ] Existing Phase 6 verifiers (`verify_grid_sample_gpu.py`, `verify_layout_unfold_gpu.py`, `verify_utils_grad.py`, `verify_phase4d_*.py`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)