### PR TITLE
Phase 6 finalize: grid_sample native MLX + module numpy purge

### DIFF
--- a/lucid/_C/nn/Spatial.cpp
+++ b/lucid/_C/nn/Spatial.cpp
@@ -41,6 +41,10 @@ T x_norm(int w, int W, bool align_corners) {
     return T{-1} + (T{2} * static_cast<T>(w) + T{1}) / static_cast<T>(W);
 }
 
+inline ::mlx::core::array mlx_scalar_dt(double v, ::mlx::core::Dtype dt) {
+    return ::mlx::core::astype(::mlx::core::array(static_cast<float>(v)), dt);
+}
+
 }  // namespace
 
 // =====================================================================
@@ -627,35 +631,301 @@ std::vector<Storage> GridSampleBackward::apply(Storage grad_out) {
     const int H_out = static_cast<int>(grid_shape_[1]);
     const int W_out = static_cast<int>(grid_shape_[2]);
 
+    // -----------------------------------------------------------------
+    // GPU branch — native MLX scatter_add for dinput, broadcast-reduce
+    // for dgrid. Avoids the CPU download/upload round-trip.
+    // -----------------------------------------------------------------
+    if (device_ == Device::GPU) {
+        const auto& gx_arr = std::get<GpuStorage>(saved_inputs_[0]);  // input
+        const auto& gg_arr = std::get<GpuStorage>(saved_inputs_[1]);  // grid
+        const auto& go_arr = std::get<GpuStorage>(grad_out);          // dout
+        const auto mlx_dt = gpu::to_mlx_dtype(dtype_);
+
+        auto idx0 = ::mlx::core::astype(::mlx::core::array(0), ::mlx::core::int64);
+        auto idx1 = ::mlx::core::astype(::mlx::core::array(1), ::mlx::core::int64);
+        auto gx_n = ::mlx::core::take(*gg_arr.arr, idx0, -1);  // [N, H_out, W_out]
+        auto gy_n = ::mlx::core::take(*gg_arr.arr, idx1, -1);
+
+        auto half = ::mlx::core::astype(::mlx::core::array(0.5f), mlx_dt);
+        auto one  = ::mlx::core::astype(::mlx::core::array(1.0f), mlx_dt);
+        auto zero = ::mlx::core::astype(::mlx::core::array(0.0f), mlx_dt);
+        auto Hm1f = ::mlx::core::astype(::mlx::core::array(static_cast<float>(H_in - 1)), mlx_dt);
+        auto Wm1f = ::mlx::core::astype(::mlx::core::array(static_cast<float>(W_in - 1)), mlx_dt);
+
+        auto denorm_arr = [&](const ::mlx::core::array& g, int dim) {
+            auto dim_arr = ::mlx::core::astype(::mlx::core::array(static_cast<float>(dim)), mlx_dt);
+            auto dim_m1 = ::mlx::core::astype(::mlx::core::array(static_cast<float>(dim - 1)), mlx_dt);
+            if (align_corners_) {
+                return ::mlx::core::multiply(half,
+                            ::mlx::core::multiply(::mlx::core::add(g, one), dim_m1));
+            }
+            auto num = ::mlx::core::multiply(::mlx::core::add(g, one), dim_arr);
+            return ::mlx::core::subtract(::mlx::core::multiply(half, num), half);
+        };
+        auto ix = denorm_arr(gx_n, W_in);
+        auto iy = denorm_arr(gy_n, H_in);
+
+        // Track who got clipped (bilinear + border) — dgrid is zeroed where so.
+        ::mlx::core::array clipped_x = ::mlx::core::astype(::mlx::core::array(false), ::mlx::core::bool_);
+        ::mlx::core::array clipped_y = clipped_x;
+        clipped_x = ::mlx::core::broadcast_to(clipped_x, gx_n.shape());
+        clipped_y = ::mlx::core::broadcast_to(clipped_y, gy_n.shape());
+        if (mode_ == 0 && padding_mode_ == 1) {
+            auto cx_lo = ::mlx::core::less(ix, zero);
+            auto cx_hi = ::mlx::core::greater(ix, Wm1f);
+            clipped_x = ::mlx::core::logical_or(cx_lo, cx_hi);
+            auto cy_lo = ::mlx::core::less(iy, zero);
+            auto cy_hi = ::mlx::core::greater(iy, Hm1f);
+            clipped_y = ::mlx::core::logical_or(cy_lo, cy_hi);
+            ix = ::mlx::core::clip(ix, std::optional<::mlx::core::array>(zero),
+                                       std::optional<::mlx::core::array>(Wm1f));
+            iy = ::mlx::core::clip(iy, std::optional<::mlx::core::array>(zero),
+                                       std::optional<::mlx::core::array>(Hm1f));
+        }
+
+        const std::int64_t total_in = static_cast<std::int64_t>(N) * C * H_in * W_in;
+        auto in_flat = ::mlx::core::reshape(*gx_arr.arr, {static_cast<int>(total_in)});
+
+        // Stride constants in int64 for flat-index arithmetic.
+        auto sn = ::mlx::core::astype(::mlx::core::array(C * H_in * W_in), ::mlx::core::int64);
+        auto sc = ::mlx::core::astype(::mlx::core::array(H_in * W_in), ::mlx::core::int64);
+        auto sy = ::mlx::core::astype(::mlx::core::array(W_in), ::mlx::core::int64);
+        auto n_idx = ::mlx::core::reshape(
+            ::mlx::core::astype(::mlx::core::arange(0, N, 1), ::mlx::core::int64),
+            {N, 1, 1, 1});
+        auto c_idx = ::mlx::core::reshape(
+            ::mlx::core::astype(::mlx::core::arange(0, C, 1), ::mlx::core::int64),
+            {1, C, 1, 1});
+
+        // Build (yi_int, xi_int) -> flat_idx[N, C, H_out, W_out] (broadcast over C),
+        // and a mask of in-bounds positions if zeros padding.
+        auto build_flat_idx = [&](const ::mlx::core::array& yi,
+                                    const ::mlx::core::array& xi) {
+            auto y_b = ::mlx::core::reshape(yi, {N, 1, H_out, W_out});
+            auto x_b = ::mlx::core::reshape(xi, {N, 1, H_out, W_out});
+            auto flat = ::mlx::core::add(
+                ::mlx::core::add(::mlx::core::multiply(n_idx, sn),
+                                   ::mlx::core::multiply(c_idx, sc)),
+                ::mlx::core::add(::mlx::core::multiply(y_b, sy), x_b));
+            return ::mlx::core::broadcast_to(flat, {N, C, H_out, W_out});
+        };
+        auto build_in_bounds_mask = [&](const ::mlx::core::array& yi_pre_clip,
+                                          const ::mlx::core::array& xi_pre_clip) {
+            auto zero_i = ::mlx::core::astype(::mlx::core::array(0), ::mlx::core::int64);
+            auto Hm1_i = ::mlx::core::astype(::mlx::core::array(H_in - 1), ::mlx::core::int64);
+            auto Wm1_i = ::mlx::core::astype(::mlx::core::array(W_in - 1), ::mlx::core::int64);
+            auto in_y = ::mlx::core::logical_and(
+                ::mlx::core::greater_equal(yi_pre_clip, zero_i),
+                ::mlx::core::less_equal(yi_pre_clip, Hm1_i));
+            auto in_x = ::mlx::core::logical_and(
+                ::mlx::core::greater_equal(xi_pre_clip, zero_i),
+                ::mlx::core::less_equal(xi_pre_clip, Wm1_i));
+            return ::mlx::core::logical_and(in_y, in_x);
+        };
+
+        // Initial dinput buffer (flat). Each corner scatter accumulates into it.
+        auto dinput_flat = ::mlx::core::zeros({static_cast<int>(total_in)}, mlx_dt);
+
+        ::mlx::core::array dgrid_x = zero;
+        ::mlx::core::array dgrid_y = zero;
+        dgrid_x = ::mlx::core::broadcast_to(dgrid_x, gx_n.shape());
+        dgrid_y = ::mlx::core::broadcast_to(dgrid_y, gy_n.shape());
+
+        if (mode_ == 1) {
+            // Nearest: single corner; dgrid = 0.
+            auto ixr_f = ::mlx::core::round(ix, 0);
+            auto iyr_f = ::mlx::core::round(iy, 0);
+            auto ixr = ::mlx::core::astype(ixr_f, ::mlx::core::int64);
+            auto iyr = ::mlx::core::astype(iyr_f, ::mlx::core::int64);
+            auto in_bounds = build_in_bounds_mask(iyr, ixr);
+            auto zero_i = ::mlx::core::astype(::mlx::core::array(0), ::mlx::core::int64);
+            auto Hm1_i = ::mlx::core::astype(::mlx::core::array(H_in - 1), ::mlx::core::int64);
+            auto Wm1_i = ::mlx::core::astype(::mlx::core::array(W_in - 1), ::mlx::core::int64);
+            ixr = ::mlx::core::clip(ixr,
+                std::optional<::mlx::core::array>(zero_i),
+                std::optional<::mlx::core::array>(Wm1_i));
+            iyr = ::mlx::core::clip(iyr,
+                std::optional<::mlx::core::array>(zero_i),
+                std::optional<::mlx::core::array>(Hm1_i));
+            auto flat_idx = build_flat_idx(iyr, ixr);  // [N, C, H_out, W_out]
+            auto contrib = *go_arr.arr;  // [N, C, H_out, W_out]
+            if (padding_mode_ == 0) {
+                auto mask = ::mlx::core::astype(::mlx::core::reshape(in_bounds,
+                                {N, 1, H_out, W_out}), mlx_dt);
+                auto mask_b = ::mlx::core::broadcast_to(mask, {N, C, H_out, W_out});
+                contrib = ::mlx::core::multiply(contrib, mask_b);
+            }
+            // Flatten to 1-D and scatter_add into dinput_flat.
+            // MLX contract: updates.ndim == a.ndim + indices.ndim. With
+            // a [K] (rank 1) and indices [M] (rank 1), updates must be
+            // [M, 1] — the trailing 1 is the "slice into a" dim.
+            auto flat_idx_1d = ::mlx::core::reshape(flat_idx,
+                {N * C * H_out * W_out});
+            auto contrib_2d = ::mlx::core::reshape(contrib,
+                {N * C * H_out * W_out, 1});
+            dinput_flat = ::mlx::core::scatter_add(dinput_flat, flat_idx_1d,
+                                                       contrib_2d, /*axis=*/0);
+        } else {
+            // Bilinear: 4 corners.
+            auto x0 = ::mlx::core::astype(::mlx::core::floor(ix), ::mlx::core::int64);
+            auto y0 = ::mlx::core::astype(::mlx::core::floor(iy), ::mlx::core::int64);
+            auto one_i = ::mlx::core::astype(::mlx::core::array(1), ::mlx::core::int64);
+            auto x1 = ::mlx::core::add(x0, one_i);
+            auto y1 = ::mlx::core::add(y0, one_i);
+
+            auto x0_f = ::mlx::core::astype(x0, mlx_dt);
+            auto y0_f = ::mlx::core::astype(y0, mlx_dt);
+            auto x1_f = ::mlx::core::astype(x1, mlx_dt);
+            auto y1_f = ::mlx::core::astype(y1, mlx_dt);
+            auto wa = ::mlx::core::multiply(::mlx::core::subtract(x1_f, ix),
+                            ::mlx::core::subtract(y1_f, iy));
+            auto wb = ::mlx::core::multiply(::mlx::core::subtract(x1_f, ix),
+                            ::mlx::core::subtract(iy, y0_f));
+            auto wc = ::mlx::core::multiply(::mlx::core::subtract(ix, x0_f),
+                            ::mlx::core::subtract(y1_f, iy));
+            auto wd = ::mlx::core::multiply(::mlx::core::subtract(ix, x0_f),
+                            ::mlx::core::subtract(iy, y0_f));
+
+            auto zero_i = ::mlx::core::astype(::mlx::core::array(0), ::mlx::core::int64);
+            auto Hm1_i = ::mlx::core::astype(::mlx::core::array(H_in - 1), ::mlx::core::int64);
+            auto Wm1_i = ::mlx::core::astype(::mlx::core::array(W_in - 1), ::mlx::core::int64);
+            auto clip_y = [&](const ::mlx::core::array& v) {
+                return ::mlx::core::clip(v,
+                    std::optional<::mlx::core::array>(zero_i),
+                    std::optional<::mlx::core::array>(Hm1_i));
+            };
+            auto clip_x = [&](const ::mlx::core::array& v) {
+                return ::mlx::core::clip(v,
+                    std::optional<::mlx::core::array>(zero_i),
+                    std::optional<::mlx::core::array>(Wm1_i));
+            };
+            auto y0c = clip_y(y0), y1c = clip_y(y1);
+            auto x0c = clip_x(x0), x1c = clip_x(x1);
+            auto in00 = build_in_bounds_mask(y0, x0);
+            auto in01 = build_in_bounds_mask(y0, x1);
+            auto in10 = build_in_bounds_mask(y1, x0);
+            auto in11 = build_in_bounds_mask(y1, x1);
+
+            // Helper: scatter_add(go * w * mask) into dinput_flat for one corner.
+            auto scatter_one_corner = [&](const ::mlx::core::array& yi,
+                                            const ::mlx::core::array& xi,
+                                            const ::mlx::core::array& w,
+                                            const ::mlx::core::array& in_bounds) {
+                auto flat_idx = build_flat_idx(yi, xi);
+                auto w_b = ::mlx::core::broadcast_to(
+                    ::mlx::core::reshape(w, {N, 1, H_out, W_out}),
+                    {N, C, H_out, W_out});
+                ::mlx::core::array contrib = ::mlx::core::multiply(*go_arr.arr, w_b);
+                if (padding_mode_ == 0) {
+                    auto mask = ::mlx::core::astype(::mlx::core::reshape(in_bounds,
+                                    {N, 1, H_out, W_out}), mlx_dt);
+                    auto mask_b = ::mlx::core::broadcast_to(mask, {N, C, H_out, W_out});
+                    contrib = ::mlx::core::multiply(contrib, mask_b);
+                }
+                auto flat_idx_1d = ::mlx::core::reshape(flat_idx, {N * C * H_out * W_out});
+                auto contrib_2d = ::mlx::core::reshape(contrib, {N * C * H_out * W_out, 1});
+                dinput_flat = ::mlx::core::scatter_add(dinput_flat, flat_idx_1d,
+                                                            contrib_2d, /*axis=*/0);
+            };
+            scatter_one_corner(y0c, x0c, wa, in00);
+            scatter_one_corner(y1c, x0c, wb, in10);
+            scatter_one_corner(y0c, x1c, wc, in01);
+            scatter_one_corner(y1c, x1c, wd, in11);
+
+            // dgrid contributions — analytic chain through bilinear.
+            // For each corner, fetch I_corner across channels (gather from input).
+            auto fetch_corner = [&](const ::mlx::core::array& yi,
+                                      const ::mlx::core::array& xi,
+                                      const ::mlx::core::array& in_bounds) {
+                auto flat_idx = build_flat_idx(yi, xi);
+                auto vals = ::mlx::core::take(in_flat, flat_idx);
+                if (padding_mode_ == 0) {
+                    auto mask = ::mlx::core::astype(::mlx::core::reshape(in_bounds,
+                                    {N, 1, H_out, W_out}), mlx_dt);
+                    auto mask_b = ::mlx::core::broadcast_to(mask, {N, C, H_out, W_out});
+                    vals = ::mlx::core::multiply(vals, mask_b);
+                }
+                return vals;
+            };
+            auto Ia = fetch_corner(y0c, x0c, in00);
+            auto Ib = fetch_corner(y1c, x0c, in10);
+            auto Ic = fetch_corner(y0c, x1c, in01);
+            auto Id = fetch_corner(y1c, x1c, in11);
+
+            // dy_term1 = y1_f - iy ; dy_term2 = iy - y0_f
+            auto dy_t1 = ::mlx::core::subtract(y1_f, iy);
+            auto dy_t2 = ::mlx::core::subtract(iy, y0_f);
+            auto dx_t1 = ::mlx::core::subtract(x1_f, ix);
+            auto dx_t2 = ::mlx::core::subtract(ix, x0_f);
+            auto dy_t1_b = ::mlx::core::broadcast_to(
+                ::mlx::core::reshape(dy_t1, {N, 1, H_out, W_out}),
+                {N, C, H_out, W_out});
+            auto dy_t2_b = ::mlx::core::broadcast_to(
+                ::mlx::core::reshape(dy_t2, {N, 1, H_out, W_out}),
+                {N, C, H_out, W_out});
+            auto dx_t1_b = ::mlx::core::broadcast_to(
+                ::mlx::core::reshape(dx_t1, {N, 1, H_out, W_out}),
+                {N, C, H_out, W_out});
+            auto dx_t2_b = ::mlx::core::broadcast_to(
+                ::mlx::core::reshape(dx_t2, {N, 1, H_out, W_out}),
+                {N, C, H_out, W_out});
+            // dix_per_chan = go * ((Ic - Ia) * dy_t1 + (Id - Ib) * dy_t2)
+            auto dix_per = ::mlx::core::multiply(*go_arr.arr,
+                ::mlx::core::add(::mlx::core::multiply(::mlx::core::subtract(Ic, Ia), dy_t1_b),
+                                 ::mlx::core::multiply(::mlx::core::subtract(Id, Ib), dy_t2_b)));
+            // diy_per = go * ((Ib - Ia) * dx_t1 + (Id - Ic) * dx_t2)
+            auto diy_per = ::mlx::core::multiply(*go_arr.arr,
+                ::mlx::core::add(::mlx::core::multiply(::mlx::core::subtract(Ib, Ia), dx_t1_b),
+                                 ::mlx::core::multiply(::mlx::core::subtract(Id, Ic), dx_t2_b)));
+            // Sum over channel axis to get [N, H_out, W_out].
+            auto dix_sum = ::mlx::core::sum(dix_per, std::vector<int>{1}, /*keepdims=*/false);
+            auto diy_sum = ::mlx::core::sum(diy_per, std::vector<int>{1}, /*keepdims=*/false);
+            auto sx = mlx_scalar_dt(static_cast<double>(W_in - (align_corners_ ? 1 : 0)) / 2.0,
+                                   mlx_dt);
+            // align: (in - 1) / 2;  not align: in / 2.
+            sx = align_corners_
+                  ? mlx_scalar_dt(static_cast<double>(W_in - 1) / 2.0, mlx_dt)
+                  : mlx_scalar_dt(static_cast<double>(W_in) / 2.0, mlx_dt);
+            auto sy_arr = align_corners_
+                  ? mlx_scalar_dt(static_cast<double>(H_in - 1) / 2.0, mlx_dt)
+                  : mlx_scalar_dt(static_cast<double>(H_in) / 2.0, mlx_dt);
+            dgrid_x = ::mlx::core::multiply(dix_sum, sx);
+            dgrid_y = ::mlx::core::multiply(diy_sum, sy_arr);
+            // border + clipped → zero out dgrid contribution.
+            if (padding_mode_ == 1) {
+                auto inv_x = ::mlx::core::logical_not(clipped_x);
+                auto inv_y = ::mlx::core::logical_not(clipped_y);
+                auto mx = ::mlx::core::astype(inv_x, mlx_dt);
+                auto my = ::mlx::core::astype(inv_y, mlx_dt);
+                dgrid_x = ::mlx::core::multiply(dgrid_x, mx);
+                dgrid_y = ::mlx::core::multiply(dgrid_y, my);
+            }
+        }
+
+        // Reshape dinput back to [N, C, H_in, W_in].
+        auto dx_arr = ::mlx::core::reshape(dinput_flat,
+            gpu::to_mlx_shape(input_shape_));
+
+        // Stack dgrid_x, dgrid_y into [N, H_out, W_out, 2].
+        auto dgx_e = ::mlx::core::expand_dims(dgrid_x, /*axis=*/-1);
+        auto dgy_e = ::mlx::core::expand_dims(dgrid_y, /*axis=*/-1);
+        auto dg_arr = ::mlx::core::concatenate(
+            std::vector<::mlx::core::array>{dgx_e, dgy_e}, -1);
+        return {Storage{gpu::wrap_mlx_array(std::move(dx_arr), dtype_)},
+                Storage{gpu::wrap_mlx_array(std::move(dg_arr), dtype_)}};
+    }
+
+    // -----------------------------------------------------------------
+    // CPU branch (analytic forward+backward, unchanged).
+    // -----------------------------------------------------------------
     auto dx = allocate_size(static_cast<std::size_t>(N) * C * H_in * W_in, dtype_);
     auto dg = allocate_size(static_cast<std::size_t>(N) * H_out * W_out * 2, dtype_);
     std::memset(dx.ptr.get(), 0, dx.nbytes);
     std::memset(dg.ptr.get(), 0, dg.nbytes);
 
-    CpuStorage xs_gpu_download;
-    CpuStorage gs_gpu_download;
-    CpuStorage gout_gpu_download;
-    const CpuStorage* xs_ptr = nullptr;
-    const CpuStorage* gs_ptr = nullptr;
-    const CpuStorage* gout_ptr = nullptr;
-    if (device_ == Device::GPU) {
-        xs_gpu_download = gpu::download_gpu_to_cpu(
-            std::get<GpuStorage>(saved_inputs_[0]), input_shape_);
-        gs_gpu_download = gpu::download_gpu_to_cpu(
-            std::get<GpuStorage>(saved_inputs_[1]), grid_shape_);
-        gout_gpu_download = gpu::download_gpu_to_cpu(
-            std::get<GpuStorage>(grad_out), out_shape_);
-        xs_ptr = &xs_gpu_download;
-        gs_ptr = &gs_gpu_download;
-        gout_ptr = &gout_gpu_download;
-    } else {
-        xs_ptr = &std::get<CpuStorage>(saved_inputs_[0]);
-        gs_ptr = &std::get<CpuStorage>(saved_inputs_[1]);
-        gout_ptr = &std::get<CpuStorage>(grad_out);
-    }
-    const auto& xs = *xs_ptr;
-    const auto& gs = *gs_ptr;
-    const auto& gout = *gout_ptr;
+    const auto& xs   = std::get<CpuStorage>(saved_inputs_[0]);
+    const auto& gs   = std::get<CpuStorage>(saved_inputs_[1]);
+    const auto& gout = std::get<CpuStorage>(grad_out);
 
     auto run = [&](auto type_tag) {
         using T = decltype(type_tag);

--- a/lucid/nn/modules/conv.py
+++ b/lucid/nn/modules/conv.py
@@ -242,16 +242,15 @@ class _ConstrainedConvNd(_ConvNd):
                     "fixed_center requires odd kernel sizes for all spatial dims."
                 )
 
-            # Build a one-hot mask whose only nonzero entry is the kernel center.
+            # One-time mask construction (init-time only; not in compute path).
             import numpy as np
-
             mask = np.zeros((1, 1, *self.kernel_size), dtype=np.float32)
             center_idx = (0, 0, *[k // 2 for k in self.kernel_size])
             mask[center_idx] = 1.0
             center_mask = Tensor(mask, device=self.device)
-
             self.register_buffer("_center_mask", center_mask)
-            self.register_buffer("_neighbor_mask", Tensor(1.0 - mask, device=self.device))
+            self.register_buffer("_neighbor_mask",
+                                  Tensor(1.0 - mask, device=self.device))
         else:
             self.register_buffer("_center_mask", None)
             self.register_buffer("_neighbor_mask", None)

--- a/lucid/nn/modules/rnn.py
+++ b/lucid/nn/modules/rnn.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-import numpy as np
 
 import lucid
 import lucid.nn as nn
@@ -50,14 +49,9 @@ def _get_activation(nonlinearity: str) -> type[nn.Module]:
 
 
 def _uniform_param(low: float, high: float, shape: tuple[int, ...]) -> Tensor:
-    """Build a fresh uniformly-distributed Tensor on CPU.
-
-    Routes through numpy because `lucid.random.uniform` uses keyword
-    `low=` / `high=` and `Parameter` ultimately re-uploads via numpy
-    anyway.
-    """
-    arr = np.random.uniform(low, high, size=shape).astype(np.float32)
-    return Tensor(arr)
+    """Build a fresh uniformly-distributed Tensor on CPU via the engine RNG."""
+    from lucid.ops.random import uniform
+    return uniform(*shape, low=low, high=high)
 
 
 class RNNCell(nn.Module):

--- a/lucid/nn/modules/sparse.py
+++ b/lucid/nn/modules/sparse.py
@@ -4,7 +4,6 @@ lucid.nn.modules.sparse — embedding tables.
 
 from __future__ import annotations
 
-import numpy as np
 
 import lucid
 import lucid.nn as nn
@@ -52,13 +51,16 @@ class Embedding(nn.Module):
             self._zero_padding_row()
 
     def _make_init_weight(self) -> Tensor:
-        arr = np.random.uniform(
-            -0.1, 0.1, size=(self.num_embeddings, self.embedding_dim)
-        ).astype(np.float32)
-        return Tensor(arr)
+        from lucid.ops.random import uniform
+        return uniform(self.num_embeddings, self.embedding_dim,
+                        low=-0.1, high=0.1)
 
     def _zero_padding_row(self) -> None:
-        # Replace weight._impl with a copy where the padding row is zeroed.
+        # One-time initialization helper: zero the padding row in-place.
+        # Done via host round-trip because Tensor does not expose
+        # __setitem__ for slice assignment yet; this is *not* in any
+        # forward/backward compute path.
+        import numpy as np
         arr = self.weight.numpy().copy()
         arr[self.padding_idx] = 0
         new = Tensor(arr, dtype=self.weight.dtype, device=self.weight.device)
@@ -71,7 +73,11 @@ class Embedding(nn.Module):
 
     def reset_parameters(self) -> None:
         new = self._make_init_weight()
-        new = Tensor(new.numpy(), dtype=self.weight.dtype, device=self.weight.device)
+        # Move to weight's device/dtype if needed.
+        if new.dtype != self.weight.dtype:
+            new = new.astype(self.weight.dtype)
+        if new.device != self.weight.device:
+            new = new.to(self.weight.device)
         self.weight._impl = new._impl
         if self.padding_idx is not None:
             self._zero_padding_row()


### PR DESCRIPTION
## Summary

Closes out Phase 6. Two cleanups bundled into one PR per the new "PR-per-phase" cadence:

1. **`grid_sample` backward — fully native MLX** (no more CPU bridge).
2. **`nn/modules` numpy fallback purge** (Phase 6-10) for the operations that actually run on the forward/backward path.

## What changed

### 1. `grid_sample` GPU backward (`nn/Spatial.cpp`)

Replaces the previous correctness-first download/upload bridge with native MLX scatter:
- `dinput`: 4 corner contributions (1 for nearest) computed in MLX, then `mlx::core::scatter_add` into a flat `[N*C*H_in*W_in]` buffer. The MLX C++ contract requires `updates.ndim == a.ndim + indices.ndim`, so the `[K]`-shaped contributions are reshaped to `[K, 1]` before scatter.
- `dgrid`: analytic chain rule expressed entirely as broadcast multiplies + sum over the channel axis. Border-clipped positions are zeroed via `logical_or` → `astype` masking.
- All 4 mode × padding combos (bilinear/nearest × zeros/border) produce identical results to the CPU path; previous regression script `scripts/verify_grid_sample_gpu.py` reports 9/9.

### 2. `nn/modules` numpy purge (Phase 6-10)

- `rnn.py::_uniform_param` now goes through `lucid.ops.random.uniform` (engine's seeded Philox path) — `RNNCell` / `LSTMCell` / `GRUCell` / `LSTM` all reset cleanly.
- `sparse.py::Embedding._make_init_weight` likewise routes to `lucid.ops.random.uniform`.
- `sparse.py::_zero_padding_row` and `conv.py` fixed-center mask construction stay on a one-time numpy host buffer, intentionally — these are init-time helpers that never touch a forward/backward call. They're tagged in the comment so future cleanups know it's deliberate.
- `import numpy as np` removed from `rnn.py` and `sparse.py`.

## Verification

All eligible regression scripts continue to pass on Apple Silicon (Python 3.14, MLX latest):

| Script | Result |
|--------|--------|
| `scripts/verify_grid_sample_gpu.py` | 9 / 9 |
| `scripts/verify_layout_unfold_gpu.py` | 12 / 12 |
| `scripts/verify_utils_grad.py` | 28 / 28 |
| `scripts/verify_phase4d_grad.py` | 11 / 11 |
| `scripts/verify_phase4d_cpu.py` | 21 / 21 |
| `scripts/verify_phase6_9.py` | 28 / 28 |
| **Total** | **109 / 109** |

Plus an inline smoke test confirming `nn.Embedding(N, D, padding_idx=…)`, `RNNCell`, `LSTMCell`, `GRUCell` all instantiate and produce the expected weight shapes.

## Notes for reviewers
- `verify_engine_full.py` and `verify_complete.py` fail on this branch but they were already broken on `lucid-3.0` (one expects an obsolete `_C.engine.linear` symbol; the other passes a `uint8` numpy array that the dtype guard from PR #38 now rejects). Neither failure is in any code touched by this PR.
- The remaining numpy in `_zero_padding_row` and `fixed_center` is intentionally retained until `Tensor.__setitem__` lands; both are init-time only.
- This closes Phase 6 — next PR will be Phase 5 resumption (5-13 → 5-20: `lucid.empty` and friends at the top level, parity sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)