### PR TITLE
chore: rename _C engine aliases to _C_engine per project convention

### DIFF
--- a/lucid/__init__.py
+++ b/lucid/__init__.py
@@ -112,8 +112,8 @@ def shape(a):
 # Top-level grad-state queries (read-only)
 def grad_enabled() -> bool:
     """True if autograd is currently enabled in this thread."""
-    from lucid._C import engine as _eng
-    return _eng.GradMode.is_enabled()
+    from lucid._C import engine as _C_engine
+    return _C_engine.GradMode.is_enabled()
 
 
 # --- Tensor arithmetic + comparison + indexing dunders ----------------------

--- a/lucid/optim/__init__.py
+++ b/lucid/optim/__init__.py
@@ -9,7 +9,7 @@ so callers can pass ``lucid.Tensor`` / ``lucid.nn.Parameter`` lists
 from __future__ import annotations
 
 from typing import Iterable
-from lucid._C import engine as _eng
+from lucid._C import engine as _C_engine
 from lucid._tensor import Tensor
 
 
@@ -35,18 +35,18 @@ def _make(cls):
     return _Wrapped
 
 
-Optimizer = _eng.Optimizer
-SGD       = _make(_eng.SGD)
-Adam      = _make(_eng.Adam)
-AdamW     = _make(_eng.AdamW)
-NAdam     = _make(_eng.NAdam)
-RAdam     = _make(_eng.RAdam)
-Adamax    = _make(_eng.Adamax)
-Adagrad   = _make(_eng.Adagrad)
-Adadelta  = _make(_eng.Adadelta)
-RMSprop   = _make(_eng.RMSprop)
-Rprop     = _make(_eng.Rprop)
-ASGD      = _make(_eng.ASGD)
+Optimizer = _C_engine.Optimizer
+SGD       = _make(_C_engine.SGD)
+Adam      = _make(_C_engine.Adam)
+AdamW     = _make(_C_engine.AdamW)
+NAdam     = _make(_C_engine.NAdam)
+RAdam     = _make(_C_engine.RAdam)
+Adamax    = _make(_C_engine.Adamax)
+Adagrad   = _make(_C_engine.Adagrad)
+Adadelta  = _make(_C_engine.Adadelta)
+RMSprop   = _make(_C_engine.RMSprop)
+Rprop     = _make(_C_engine.Rprop)
+ASGD      = _make(_C_engine.ASGD)
 
 from lucid.optim import lr_scheduler  # noqa: F401
 

--- a/lucid/optim/lr_scheduler/__init__.py
+++ b/lucid/optim/lr_scheduler/__init__.py
@@ -4,20 +4,20 @@ lucid.optim.lr_scheduler — learning-rate schedules from the C++ engine.
 
 from __future__ import annotations
 
-from lucid._C import engine as _eng
+from lucid._C import engine as _C_engine
 
-LRScheduler = _eng.LRScheduler
-LambdaLR = _eng.LambdaLR
-StepLR = _eng.StepLR
-MultiStepLR = _eng.MultiStepLR
-ExponentialLR = _eng.ExponentialLR
-CosineAnnealingLR = _eng.CosineAnnealingLR
-ReduceLROnPlateau = _eng.ReduceLROnPlateau
-CyclicLR = _eng.CyclicLR
+LRScheduler = _C_engine.LRScheduler
+LambdaLR = _C_engine.LambdaLR
+StepLR = _C_engine.StepLR
+MultiStepLR = _C_engine.MultiStepLR
+ExponentialLR = _C_engine.ExponentialLR
+CosineAnnealingLR = _C_engine.CosineAnnealingLR
+ReduceLROnPlateau = _C_engine.ReduceLROnPlateau
+CyclicLR = _C_engine.CyclicLR
 
 # NoamScheduler is currently legacy-only; keep the import optional.
 try:
-    NoamScheduler = _eng.NoamScheduler
+    NoamScheduler = _C_engine.NoamScheduler
 except AttributeError:  # pragma: no cover
     pass
 

--- a/scripts/verify_complete.py
+++ b/scripts/verify_complete.py
@@ -15,7 +15,7 @@ roundoff in finite-difference probes.
 import sys
 import numpy as np
 
-from lucid._C import engine as eng
+from lucid._C import engine as _C_engine
 from lucid._C.engine import linalg as la
 
 PASSED = 0
@@ -28,8 +28,8 @@ def to_np(t):
 
 
 def make(arr, gpu=False, requires_grad=False):
-    return eng.TensorImpl(arr.copy(),
-                          eng.Device.GPU if gpu else eng.Device.CPU,
+    return _C_engine.TensorImpl(arr.copy(),
+                          _C_engine.Device.GPU if gpu else _C_engine.Device.CPU,
                           requires_grad)
 
 
@@ -70,7 +70,7 @@ def section(t):
 def grad_of(out, leaves):
     for leaf in leaves:
         leaf.zero_grad()
-    eng.engine_backward(out, retain_graph=False)
+    _C_engine.engine_backward(out, retain_graph=False)
     return [np.array(leaf.grad_as_python()) for leaf in leaves]
 
 
@@ -104,60 +104,60 @@ def test_bfunc():
         gpu = (dev == "GPU")
         A, B = make(a, gpu), make(b, gpu)
         Pb = make(pos_b, gpu)
-        check(f"add[{dev}]", to_np(eng.add(A, B)), a + b)
-        check(f"sub[{dev}]", to_np(eng.sub(A, B)), a - b)
-        check(f"mul[{dev}]", to_np(eng.mul(A, B)), a * b)
-        check(f"div[{dev}]", to_np(eng.div(A, Pb)), a / pos_b)
-        check(f"pow[{dev}]", to_np(eng.pow(make(np.abs(a) + 0.1, gpu), B)),
+        check(f"add[{dev}]", to_np(_C_engine.add(A, B)), a + b)
+        check(f"sub[{dev}]", to_np(_C_engine.sub(A, B)), a - b)
+        check(f"mul[{dev}]", to_np(_C_engine.mul(A, B)), a * b)
+        check(f"div[{dev}]", to_np(_C_engine.div(A, Pb)), a / pos_b)
+        check(f"pow[{dev}]", to_np(_C_engine.pow(make(np.abs(a) + 0.1, gpu), B)),
               np.power(np.abs(a) + 0.1, b))
-        check(f"maximum[{dev}]", to_np(eng.maximum(A, B)), np.maximum(a, b))
-        check(f"minimum[{dev}]", to_np(eng.minimum(A, B)), np.minimum(a, b))
+        check(f"maximum[{dev}]", to_np(_C_engine.maximum(A, B)), np.maximum(a, b))
+        check(f"minimum[{dev}]", to_np(_C_engine.minimum(A, B)), np.minimum(a, b))
 
         M1 = rng.standard_normal((3, 4)).astype(np.float32)
         M2 = rng.standard_normal((4, 5)).astype(np.float32)
         check(f"matmul[{dev}]",
-              to_np(eng.matmul(make(M1, gpu), make(M2, gpu))), M1 @ M2)
+              to_np(_C_engine.matmul(make(M1, gpu), make(M2, gpu))), M1 @ M2)
 
         # compare ops
-        check(f"equal[{dev}]",         to_np(eng.equal(A, B)),         a == b, exact=True)
-        check(f"not_equal[{dev}]",     to_np(eng.not_equal(A, B)),     a != b, exact=True)
-        check(f"greater[{dev}]",       to_np(eng.greater(A, B)),       a > b,  exact=True)
-        check(f"greater_equal[{dev}]", to_np(eng.greater_equal(A, B)), a >= b, exact=True)
-        check(f"less[{dev}]",          to_np(eng.less(A, B)),          a < b,  exact=True)
-        check(f"less_equal[{dev}]",    to_np(eng.less_equal(A, B)),    a <= b, exact=True)
+        check(f"equal[{dev}]",         to_np(_C_engine.equal(A, B)),         a == b, exact=True)
+        check(f"not_equal[{dev}]",     to_np(_C_engine.not_equal(A, B)),     a != b, exact=True)
+        check(f"greater[{dev}]",       to_np(_C_engine.greater(A, B)),       a > b,  exact=True)
+        check(f"greater_equal[{dev}]", to_np(_C_engine.greater_equal(A, B)), a >= b, exact=True)
+        check(f"less[{dev}]",          to_np(_C_engine.less(A, B)),          a < b,  exact=True)
+        check(f"less_equal[{dev}]",    to_np(_C_engine.less_equal(A, B)),    a <= b, exact=True)
 
         # bitwise
         ai = np.array([5, 3, 1, 0xff], dtype=np.int32)
         bi = np.array([3, 5, 7, 0x0f], dtype=np.int32)
         AI, BI = make(ai, gpu), make(bi, gpu)
-        check(f"bitwise_and[{dev}]", to_np(eng.bitwise_and(AI, BI)), ai & bi, exact=True)
-        check(f"bitwise_or[{dev}]",  to_np(eng.bitwise_or(AI, BI)),  ai | bi, exact=True)
-        check(f"bitwise_xor[{dev}]", to_np(eng.bitwise_xor(AI, BI)), ai ^ bi, exact=True)
+        check(f"bitwise_and[{dev}]", to_np(_C_engine.bitwise_and(AI, BI)), ai & bi, exact=True)
+        check(f"bitwise_or[{dev}]",  to_np(_C_engine.bitwise_or(AI, BI)),  ai | bi, exact=True)
+        check(f"bitwise_xor[{dev}]", to_np(_C_engine.bitwise_xor(AI, BI)), ai ^ bi, exact=True)
 
         # dot/inner/outer
         u = rng.standard_normal(5).astype(np.float32)
         v = rng.standard_normal(5).astype(np.float32)
         U, V = make(u, gpu), make(v, gpu)
-        check(f"dot1d[{dev}]", to_np(eng.dot(U, V)), np.dot(u, v))
+        check(f"dot1d[{dev}]", to_np(_C_engine.dot(U, V)), np.dot(u, v))
         K1 = rng.standard_normal((3, 4)).astype(np.float32)
         K2 = rng.standard_normal((4, 2)).astype(np.float32)
         check(f"dot2d[{dev}]",
-              to_np(eng.dot(make(K1, gpu), make(K2, gpu))), np.dot(K1, K2))
-        check(f"inner[{dev}]", to_np(eng.inner(U, V)), np.inner(u, v))
-        check(f"outer[{dev}]", to_np(eng.outer(U, V)), np.outer(u, v))
+              to_np(_C_engine.dot(make(K1, gpu), make(K2, gpu))), np.dot(K1, K2))
+        check(f"inner[{dev}]", to_np(_C_engine.inner(U, V)), np.inner(u, v))
+        check(f"outer[{dev}]", to_np(_C_engine.outer(U, V)), np.outer(u, v))
 
         # tensordot
         T1 = rng.standard_normal((3, 4, 5)).astype(np.float32)
         T2 = rng.standard_normal((5, 4, 6)).astype(np.float32)
         check(f"tensordot[{dev}]",
-              to_np(eng.tensordot(make(T1, gpu), make(T2, gpu), [2], [0])),
+              to_np(_C_engine.tensordot(make(T1, gpu), make(T2, gpu), [2], [0])),
               np.tensordot(T1, T2, axes=([2], [0])))
 
         # floordiv
         af = np.array([7.0, 8.0, 9.0, -3.0], dtype=np.float32)
         bf = np.array([2.0, 3.0, 4.0, 2.0],  dtype=np.float32)
         check(f"floordiv[{dev}]",
-              to_np(eng.floordiv(make(af, gpu), make(bf, gpu))),
+              to_np(_C_engine.floordiv(make(af, gpu), make(bf, gpu))),
               np.floor(af / bf).astype(np.int64), exact=True)
 
 
@@ -172,14 +172,14 @@ def test_bfunc_grad():
 
         # add backward: da=g, db=g
         A = make(a, gpu, True); B = make(b, gpu, True)
-        out = eng.sum(eng.add(A, B), [], False)
+        out = _C_engine.sum(_C_engine.add(A, B), [], False)
         ga, gb = grad_of(out, [A, B])
         check(f"add da[{dev}]", ga, np.ones_like(a))
         check(f"add db[{dev}]", gb, np.ones_like(b))
 
         # mul backward: da=g*b, db=g*a
         A = make(a, gpu, True); B = make(b, gpu, True)
-        out = eng.sum(eng.mul(A, B), [], False)
+        out = _C_engine.sum(_C_engine.mul(A, B), [], False)
         ga, gb = grad_of(out, [A, B])
         check(f"mul da[{dev}]", ga, b)
         check(f"mul db[{dev}]", gb, a)
@@ -188,7 +188,7 @@ def test_bfunc_grad():
         A_np = rng.standard_normal((3, 4)).astype(np.float32) * 0.3
         B_np = rng.standard_normal((4, 2)).astype(np.float32) * 0.3
         A = make(A_np, gpu, True); B = make(B_np, gpu, True)
-        out = eng.sum(eng.matmul(A, B), [], False)
+        out = _C_engine.sum(_C_engine.matmul(A, B), [], False)
         ga, gb = grad_of(out, [A, B])
         # expected: da = ones((3,2)) @ B.T, db = A.T @ ones((3,2))
         ones = np.ones((3, 2), dtype=np.float32)
@@ -199,14 +199,14 @@ def test_bfunc_grad():
         u = rng.standard_normal(5).astype(np.float32) * 0.5
         v = rng.standard_normal(5).astype(np.float32) * 0.5
         U = make(u, gpu, True); V = make(v, gpu, True)
-        out = eng.dot(U, V)
+        out = _C_engine.dot(U, V)
         gu, gv = grad_of(out, [U, V])
         check(f"dot1d du[{dev}]", gu, v)
         check(f"dot1d dv[{dev}]", gv, u)
 
         # outer backward
         U = make(u, gpu, True); V = make(v, gpu, True)
-        out = eng.sum(eng.outer(U, V), [], False)
+        out = _C_engine.sum(_C_engine.outer(U, V), [], False)
         gu, gv = grad_of(out, [U, V])
         check(f"outer du[{dev}]", gu, np.ones_like(u) * v.sum())
         check(f"outer dv[{dev}]", gv, np.ones_like(v) * u.sum())
@@ -226,54 +226,54 @@ def test_ufunc():
         gpu = (dev == "GPU")
         X = make(x, gpu); P = make(pos, gpu); B = make(bounded, gpu)
         # Arith
-        check(f"neg[{dev}]",        to_np(eng.neg(X)),        -x)
-        check(f"abs[{dev}]",        to_np(eng.abs(X)),        np.abs(x))
-        check(f"sign[{dev}]",       to_np(eng.sign(X)),       np.sign(x))
-        check(f"reciprocal[{dev}]", to_np(eng.reciprocal(P)), 1.0 / pos)
-        check(f"square[{dev}]",     to_np(eng.square(X)),     x * x)
-        check(f"cube[{dev}]",       to_np(eng.cube(X)),       x ** 3)
+        check(f"neg[{dev}]",        to_np(_C_engine.neg(X)),        -x)
+        check(f"abs[{dev}]",        to_np(_C_engine.abs(X)),        np.abs(x))
+        check(f"sign[{dev}]",       to_np(_C_engine.sign(X)),       np.sign(x))
+        check(f"reciprocal[{dev}]", to_np(_C_engine.reciprocal(P)), 1.0 / pos)
+        check(f"square[{dev}]",     to_np(_C_engine.square(X)),     x * x)
+        check(f"cube[{dev}]",       to_np(_C_engine.cube(X)),       x ** 3)
         # Exp/log
-        check(f"exp[{dev}]",  to_np(eng.exp(X)),  np.exp(x))
-        check(f"log[{dev}]",  to_np(eng.log(P)),  np.log(pos))
-        check(f"log2[{dev}]", to_np(eng.log2(P)), np.log2(pos))
-        check(f"sqrt[{dev}]", to_np(eng.sqrt(P)), np.sqrt(pos))
+        check(f"exp[{dev}]",  to_np(_C_engine.exp(X)),  np.exp(x))
+        check(f"log[{dev}]",  to_np(_C_engine.log(P)),  np.log(pos))
+        check(f"log2[{dev}]", to_np(_C_engine.log2(P)), np.log2(pos))
+        check(f"sqrt[{dev}]", to_np(_C_engine.sqrt(P)), np.sqrt(pos))
         # Trig
-        check(f"sin[{dev}]", to_np(eng.sin(X)), np.sin(x))
-        check(f"cos[{dev}]", to_np(eng.cos(X)), np.cos(x))
-        check(f"tan[{dev}]", to_np(eng.tan(X)), np.tan(x))
-        check(f"arcsin[{dev}]", to_np(eng.arcsin(B)), np.arcsin(bounded))
-        check(f"arccos[{dev}]", to_np(eng.arccos(B)), np.arccos(bounded))
-        check(f"arctan[{dev}]", to_np(eng.arctan(X)), np.arctan(x))
+        check(f"sin[{dev}]", to_np(_C_engine.sin(X)), np.sin(x))
+        check(f"cos[{dev}]", to_np(_C_engine.cos(X)), np.cos(x))
+        check(f"tan[{dev}]", to_np(_C_engine.tan(X)), np.tan(x))
+        check(f"arcsin[{dev}]", to_np(_C_engine.arcsin(B)), np.arcsin(bounded))
+        check(f"arccos[{dev}]", to_np(_C_engine.arccos(B)), np.arccos(bounded))
+        check(f"arctan[{dev}]", to_np(_C_engine.arctan(X)), np.arctan(x))
         # Hyperbolic
-        check(f"sinh[{dev}]", to_np(eng.sinh(X)), np.sinh(x))
-        check(f"cosh[{dev}]", to_np(eng.cosh(X)), np.cosh(x))
-        check(f"tanh[{dev}]", to_np(eng.tanh(X)), np.tanh(x))
+        check(f"sinh[{dev}]", to_np(_C_engine.sinh(X)), np.sinh(x))
+        check(f"cosh[{dev}]", to_np(_C_engine.cosh(X)), np.cosh(x))
+        check(f"tanh[{dev}]", to_np(_C_engine.tanh(X)), np.tanh(x))
         # Activation
-        check(f"relu[{dev}]",       to_np(eng.relu(X)),    np.maximum(x, 0.0))
-        check(f"sigmoid[{dev}]",    to_np(eng.sigmoid(X)), 1.0 / (1.0 + np.exp(-x)))
-        check(f"silu[{dev}]",       to_np(eng.silu(X)),    x * (1.0 / (1.0 + np.exp(-x))))
-        check(f"leaky_relu[{dev}]", to_np(eng.leaky_relu(X, 0.1)),
+        check(f"relu[{dev}]",       to_np(_C_engine.relu(X)),    np.maximum(x, 0.0))
+        check(f"sigmoid[{dev}]",    to_np(_C_engine.sigmoid(X)), 1.0 / (1.0 + np.exp(-x)))
+        check(f"silu[{dev}]",       to_np(_C_engine.silu(X)),    x * (1.0 / (1.0 + np.exp(-x))))
+        check(f"leaky_relu[{dev}]", to_np(_C_engine.leaky_relu(X, 0.1)),
               np.where(x >= 0, x, 0.1 * x))
-        check(f"softplus[{dev}]",   to_np(eng.softplus(X)),
+        check(f"softplus[{dev}]",   to_np(_C_engine.softplus(X)),
               np.log1p(np.exp(x)).astype(np.float32))
         # softmax
         sm = np.exp(x - x.max(-1, keepdims=True))
         sm = sm / sm.sum(-1, keepdims=True)
-        check(f"softmax[{dev}]", to_np(eng.softmax(X, -1)), sm)
+        check(f"softmax[{dev}]", to_np(_C_engine.softmax(X, -1)), sm)
 
         # Scalar param
-        check(f"pow_scalar[{dev}]",  to_np(eng.pow_scalar(P, 2.0)), pos ** 2)
-        check(f"rpow_scalar[{dev}]", to_np(eng.rpow_scalar(2.0, X)), 2.0 ** x)
-        check(f"clip[{dev}]", to_np(eng.clip(X, -0.5, 0.5)), np.clip(x, -0.5, 0.5))
+        check(f"pow_scalar[{dev}]",  to_np(_C_engine.pow_scalar(P, 2.0)), pos ** 2)
+        check(f"rpow_scalar[{dev}]", to_np(_C_engine.rpow_scalar(2.0, X)), 2.0 ** x)
+        check(f"clip[{dev}]", to_np(_C_engine.clip(X, -0.5, 0.5)), np.clip(x, -0.5, 0.5))
 
         # Discrete
         h = (x * 4).astype(np.float32)
         H = make(h, gpu)
-        check(f"round[{dev}]", to_np(eng.round(H)), np.round(h))
-        check(f"floor[{dev}]", to_np(eng.floor(H)), np.floor(h))
-        check(f"ceil[{dev}]",  to_np(eng.ceil(H)),  np.ceil(h))
+        check(f"round[{dev}]", to_np(_C_engine.round(H)), np.round(h))
+        check(f"floor[{dev}]", to_np(_C_engine.floor(H)), np.floor(h))
+        check(f"ceil[{dev}]",  to_np(_C_engine.ceil(H)),  np.ceil(h))
         ints = np.array([5, 3, 0, -1], dtype=np.int32)
-        check(f"invert[{dev}]", to_np(eng.invert(make(ints, gpu))), ~ints, exact=True)
+        check(f"invert[{dev}]", to_np(_C_engine.invert(make(ints, gpu))), ~ints, exact=True)
 
 
 def test_ufunc_grad():
@@ -285,32 +285,32 @@ def test_ufunc_grad():
     for dev in ("CPU", "GPU"):
         gpu = (dev == "GPU")
         X = make(x, gpu, True)
-        out = eng.sum(eng.exp(X), [], False)
+        out = _C_engine.sum(_C_engine.exp(X), [], False)
         [g] = grad_of(out, [X])
         check(f"exp grad[{dev}]", g, np.exp(x))
 
         X = make(pos, gpu, True)
-        out = eng.sum(eng.log(X), [], False)
+        out = _C_engine.sum(_C_engine.log(X), [], False)
         [g] = grad_of(out, [X])
         check(f"log grad[{dev}]", g, 1.0 / pos)
 
         X = make(x, gpu, True)
-        out = eng.sum(eng.square(X), [], False)
+        out = _C_engine.sum(_C_engine.square(X), [], False)
         [g] = grad_of(out, [X])
         check(f"square grad[{dev}]", g, 2 * x)
 
         X = make(x, gpu, True)
-        out = eng.sum(eng.tanh(X), [], False)
+        out = _C_engine.sum(_C_engine.tanh(X), [], False)
         [g] = grad_of(out, [X])
         check(f"tanh grad[{dev}]", g, 1.0 - np.tanh(x) ** 2)
 
         X = make(x, gpu, True)
-        out = eng.sum(eng.relu(X), [], False)
+        out = _C_engine.sum(_C_engine.relu(X), [], False)
         [g] = grad_of(out, [X])
         check(f"relu grad[{dev}]", g, (x > 0).astype(np.float32))
 
         X = make(x, gpu, True)
-        out = eng.sum(eng.sigmoid(X), [], False)
+        out = _C_engine.sum(_C_engine.sigmoid(X), [], False)
         [g] = grad_of(out, [X])
         s = 1.0 / (1.0 + np.exp(-x))
         check(f"sigmoid grad[{dev}]", g, s * (1.0 - s))
@@ -324,25 +324,25 @@ def test_reduction_grad():
     for dev in ("CPU", "GPU"):
         gpu = (dev == "GPU")
         X = make(x, gpu, True)
-        out = eng.sum(X, [], False)
+        out = _C_engine.sum(X, [], False)
         [g] = grad_of(out, [X])
         check(f"sum grad[{dev}]", g, np.ones_like(x))
 
         X = make(x, gpu, True)
-        out = eng.mean(X, [], False)
+        out = _C_engine.mean(X, [], False)
         [g] = grad_of(out, [X])
         check(f"mean grad[{dev}]", g, np.ones_like(x) / x.size)
 
         # var grad: 2/N * (x - mean)
         X = make(x, gpu, True)
-        out = eng.var(X, [], False)
+        out = _C_engine.var(X, [], False)
         [g] = grad_of(out, [X])
         N = x.size
         check(f"var grad[{dev}]", g, 2.0 / N * (x - x.mean()))
 
         # cumsum grad
         X = make(x, gpu, True)
-        out = eng.sum(eng.cumsum(X, 1), [], False)
+        out = _C_engine.sum(_C_engine.cumsum(X, 1), [], False)
         [g] = grad_of(out, [X])
         # grad = reverse(cumsum(reverse(ones, axis=1), axis=1), axis=1)
         ones = np.ones_like(x)
@@ -357,26 +357,26 @@ def test_gfunc():
     section("gfunc forward (CPU + GPU)")
     for dev in ("CPU", "GPU"):
         gpu = (dev == "GPU")
-        d = eng.Device.GPU if gpu else eng.Device.CPU
-        check(f"zeros[{dev}]", to_np(eng.zeros([2, 3], dtype=eng.Dtype.F32, device=d)),
+        d = _C_engine.Device.GPU if gpu else _C_engine.Device.CPU
+        check(f"zeros[{dev}]", to_np(_C_engine.zeros([2, 3], dtype=_C_engine.Dtype.F32, device=d)),
               np.zeros((2, 3), np.float32))
-        check(f"ones[{dev}]", to_np(eng.ones([2, 3], dtype=eng.Dtype.F32, device=d)),
+        check(f"ones[{dev}]", to_np(_C_engine.ones([2, 3], dtype=_C_engine.Dtype.F32, device=d)),
               np.ones((2, 3), np.float32))
-        check(f"full[{dev}]", to_np(eng.full([2, 3], 3.14, dtype=eng.Dtype.F32, device=d)),
+        check(f"full[{dev}]", to_np(_C_engine.full([2, 3], 3.14, dtype=_C_engine.Dtype.F32, device=d)),
               np.full((2, 3), 3.14, np.float32))
-        check(f"eye[{dev}]", to_np(eng.eye(3, 4, 1, dtype=eng.Dtype.F32, device=d)),
+        check(f"eye[{dev}]", to_np(_C_engine.eye(3, 4, 1, dtype=_C_engine.Dtype.F32, device=d)),
               np.eye(3, 4, k=1, dtype=np.float32))
-        check(f"arange[{dev}]", to_np(eng.arange(0.0, 5.0, 1.0, dtype=eng.Dtype.F32, device=d)),
+        check(f"arange[{dev}]", to_np(_C_engine.arange(0.0, 5.0, 1.0, dtype=_C_engine.Dtype.F32, device=d)),
               np.arange(0.0, 5.0, 1.0, np.float32))
-        check(f"linspace[{dev}]", to_np(eng.linspace(0.0, 1.0, 5, dtype=eng.Dtype.F32, device=d)),
+        check(f"linspace[{dev}]", to_np(_C_engine.linspace(0.0, 1.0, 5, dtype=_C_engine.Dtype.F32, device=d)),
               np.linspace(0.0, 1.0, 5).astype(np.float32))
 
         # _like family
         x = np.array([[1, 2], [3, 4]], dtype=np.float32)
         X = make(x, gpu)
-        check(f"zeros_like[{dev}]", to_np(eng.zeros_like(X)), np.zeros_like(x))
-        check(f"ones_like[{dev}]", to_np(eng.ones_like(X)), np.ones_like(x))
-        check(f"full_like[{dev}]", to_np(eng.full_like(X, 7.0)), np.full_like(x, 7.0))
+        check(f"zeros_like[{dev}]", to_np(_C_engine.zeros_like(X)), np.zeros_like(x))
+        check(f"ones_like[{dev}]", to_np(_C_engine.ones_like(X)), np.ones_like(x))
+        check(f"full_like[{dev}]", to_np(_C_engine.full_like(X, 7.0)), np.full_like(x, 7.0))
 
 
 # -----------------------------------------------------------------------------
@@ -394,86 +394,86 @@ def test_utils():
         A, B = make(a, gpu), make(b, gpu)
         # concat
         check(f"concatenate axis=0[{dev}]",
-              to_np(eng.concatenate([A, B], 0)), np.concatenate([a, b], 0))
+              to_np(_C_engine.concatenate([A, B], 0)), np.concatenate([a, b], 0))
         check(f"stack axis=0[{dev}]",
-              to_np(eng.stack([A, B], 0)), np.stack([a, b], 0))
+              to_np(_C_engine.stack([A, B], 0)), np.stack([a, b], 0))
         check(f"hstack[{dev}]",
-              to_np(eng.hstack([A, B])), np.hstack([a, b]))
+              to_np(_C_engine.hstack([A, B])), np.hstack([a, b]))
         check(f"vstack[{dev}]",
-              to_np(eng.vstack([A, B])), np.vstack([a, b]))
+              to_np(_C_engine.vstack([A, B])), np.vstack([a, b]))
         # split
-        parts = eng.split(A, 2, axis=1)
+        parts = _C_engine.split(A, 2, axis=1)
         np_parts = np.split(a, 2, axis=1)
         for i, (sc, sn) in enumerate(zip(parts, np_parts)):
             check(f"split[{i}][{dev}]", to_np(sc), sn)
         # repeat / tile
-        check(f"repeat[{dev}]", to_np(eng.repeat(A, 2, axis=0)),
+        check(f"repeat[{dev}]", to_np(_C_engine.repeat(A, 2, axis=0)),
               np.repeat(a, 2, axis=0))
-        check(f"tile[{dev}]", to_np(eng.tile(A, [2, 3])),
+        check(f"tile[{dev}]", to_np(_C_engine.tile(A, [2, 3])),
               np.tile(a, (2, 3)))
         # pad
-        check(f"pad[{dev}]", to_np(eng.pad(A, [(1, 1), (0, 0)], 0.0)),
+        check(f"pad[{dev}]", to_np(_C_engine.pad(A, [(1, 1), (0, 0)], 0.0)),
               np.pad(a, [(1, 1), (0, 0)]))
         # flatten
         x3 = rng.standard_normal((2, 3, 4)).astype(np.float32)
-        check(f"flatten[{dev}]", to_np(eng.flatten(make(x3, gpu), 0, -1)),
+        check(f"flatten[{dev}]", to_np(_C_engine.flatten(make(x3, gpu), 0, -1)),
               x3.reshape(-1))
         # broadcast_to
         ba = rng.standard_normal((1, 4)).astype(np.float32)
         check(f"broadcast_to[{dev}]",
-              to_np(eng.broadcast_to(make(ba, gpu), [3, 4])),
+              to_np(_C_engine.broadcast_to(make(ba, gpu), [3, 4])),
               np.broadcast_to(ba, (3, 4)))
         # tri
         sq = np.arange(9, dtype=np.float32).reshape(3, 3)
-        check(f"tril[{dev}]", to_np(eng.tril(make(sq, gpu), 0)), np.tril(sq, 0))
-        check(f"triu[{dev}]", to_np(eng.triu(make(sq, gpu), 0)), np.triu(sq, 0))
+        check(f"tril[{dev}]", to_np(_C_engine.tril(make(sq, gpu), 0)), np.tril(sq, 0))
+        check(f"triu[{dev}]", to_np(_C_engine.triu(make(sq, gpu), 0)), np.triu(sq, 0))
         # where, masked_fill
         cond = (a > 0).astype(np.uint8)
         check(f"where[{dev}]",
-              to_np(eng.where(make(cond, gpu), A, B)), np.where(cond, a, b))
+              to_np(_C_engine.where(make(cond, gpu), A, B)), np.where(cond, a, b))
         mask = (a > 0).astype(np.uint8)
         check(f"masked_fill[{dev}]",
-              to_np(eng.masked_fill(A, make(mask, gpu), 9.0)),
+              to_np(_C_engine.masked_fill(A, make(mask, gpu), 9.0)),
               np.where(mask, 9.0, a))
         # roll
-        check(f"roll[{dev}]", to_np(eng.roll(A, [1], [0])),
+        check(f"roll[{dev}]", to_np(_C_engine.roll(A, [1], [0])),
               np.roll(a, 1, axis=0))
         # gather
         idx = np.array([[2, 0, 1, 3], [1, 1, 0, 2], [3, 3, 2, 1]], dtype=np.int32)
         check(f"gather[{dev}]",
-              to_np(eng.gather(A, make(idx, gpu), 1)),
+              to_np(_C_engine.gather(A, make(idx, gpu), 1)),
               np.take_along_axis(a, idx.astype(np.int64), axis=1))
         # diagonal
         d3 = rng.standard_normal((4, 5)).astype(np.float32)
         check(f"diagonal[{dev}]",
-              to_np(eng.diagonal(make(d3, gpu), 0, -2, -1)),
+              to_np(_C_engine.diagonal(make(d3, gpu), 0, -2, -1)),
               np.diagonal(d3, 0, -2, -1))
         # sort / argsort / argmax / argmin
-        check(f"sort[{dev}]", to_np(eng.sort(A, 1)), np.sort(a, axis=1))
+        check(f"sort[{dev}]", to_np(_C_engine.sort(A, 1)), np.sort(a, axis=1))
         check(f"argsort[{dev}]",
-              to_np(eng.argsort(A, 1)).astype(np.int64),
+              to_np(_C_engine.argsort(A, 1)).astype(np.int64),
               np.argsort(a, axis=1).astype(np.int64), exact=True)
         check(f"argmax[{dev}]",
-              to_np(eng.argmax(A, axis=1, keepdims=False)),
+              to_np(_C_engine.argmax(A, axis=1, keepdims=False)),
               np.argmax(a, axis=1).astype(np.int64), exact=True)
         check(f"argmin[{dev}]",
-              to_np(eng.argmin(A, axis=0, keepdims=False)),
+              to_np(_C_engine.argmin(A, axis=0, keepdims=False)),
               np.argmin(a, axis=0).astype(np.int64), exact=True)
         # topk
-        out = to_np(eng.topk(A, 2, 1))
+        out = to_np(_C_engine.topk(A, 2, 1))
         expected = np.sort(a, axis=1)[:, ::-1][:, :2]
         check(f"topk[{dev}]", out, expected)
         # reshape / squeeze / unsqueeze / expand_dims / ravel
-        check(f"reshape[{dev}]", to_np(eng.reshape(A, [12])), a.reshape(12))
+        check(f"reshape[{dev}]", to_np(_C_engine.reshape(A, [12])), a.reshape(12))
         check(f"unsqueeze[{dev}]",
-              to_np(eng.unsqueeze(A, 0)), np.expand_dims(a, 0))
+              to_np(_C_engine.unsqueeze(A, 0)), np.expand_dims(a, 0))
         check(f"expand_dims[{dev}]",
-              to_np(eng.expand_dims(A, -1)), np.expand_dims(a, -1))
-        check(f"ravel[{dev}]", to_np(eng.ravel(A)), a.reshape(-1))
+              to_np(_C_engine.expand_dims(A, -1)), np.expand_dims(a, -1))
+        check(f"ravel[{dev}]", to_np(_C_engine.ravel(A)), a.reshape(-1))
         # meshgrid
         xv = np.array([1.0, 2.0, 3.0], dtype=np.float32)
         yv = np.array([10.0, 20.0], dtype=np.float32)
-        a_eng, b_eng = eng.meshgrid([make(xv, gpu), make(yv, gpu)],
+        a_eng, b_eng = _C_engine.meshgrid([make(xv, gpu), make(yv, gpu)],
                                      indexing_xy=False)
         a_np, b_np = np.meshgrid(xv, yv, indexing="ij")
         check(f"meshgrid[ij][A][{dev}]", to_np(a_eng), a_np)
@@ -542,7 +542,7 @@ def test_nn():
         x = rng.standard_normal((4, 5)).astype(np.float32) * 0.5
         W = rng.standard_normal((3, 5)).astype(np.float32) * 0.3
         bb = rng.standard_normal((3,)).astype(np.float32) * 0.1
-        y_eng = to_np(eng.linear(make(x, gpu), make(W, gpu), make(bb, gpu)))
+        y_eng = to_np(_C_engine.linear(make(x, gpu), make(W, gpu), make(bb, gpu)))
         check(f"linear[{dev}]", y_eng, x @ W.T + bb)
 
         # conv2d identity tap
@@ -551,13 +551,13 @@ def test_nn():
         wk[0, 0, 1, 1] = 1.0
         bc = np.zeros((1,), dtype=np.float32)
         check(f"conv2d (identity)[{dev}]",
-              to_np(eng.conv2d(make(xc, gpu), make(wk, gpu),
+              to_np(_C_engine.conv2d(make(xc, gpu), make(wk, gpu),
                                make(bc, gpu), 1, 1, 1, 1)),
               xc)
 
         # max_pool2d
         xp = rng.standard_normal((1, 2, 4, 4)).astype(np.float32)
-        out = to_np(eng.max_pool2d(make(xp, gpu), 2, 2, 2, 2, 0, 0))
+        out = to_np(_C_engine.max_pool2d(make(xp, gpu), 2, 2, 2, 2, 0, 0))
         # numpy max_pool 2x2 stride 2
         np_pool = np.zeros((1, 2, 2, 2), dtype=np.float32)
         for n in range(1):
@@ -568,7 +568,7 @@ def test_nn():
         check(f"max_pool2d[{dev}]", out, np_pool)
 
         # avg_pool2d
-        out = to_np(eng.avg_pool2d(make(xp, gpu), 2, 2, 2, 2, 0, 0))
+        out = to_np(_C_engine.avg_pool2d(make(xp, gpu), 2, 2, 2, 2, 0, 0))
         np_avg = np.zeros((1, 2, 2, 2), dtype=np.float32)
         for n in range(1):
             for c in range(2):
@@ -581,7 +581,7 @@ def test_nn():
         xbn = rng.standard_normal((4, 3, 2, 2)).astype(np.float32)
         gamma = np.ones((3,), dtype=np.float32)
         beta = np.zeros((3,), dtype=np.float32)
-        out = to_np(eng.batch_norm(make(xbn, gpu), make(gamma, gpu),
+        out = to_np(_C_engine.batch_norm(make(xbn, gpu), make(gamma, gpu),
                                    make(beta, gpu), 1e-5))
         # numpy reference (training-mode)
         mu = xbn.mean(axis=(0, 2, 3), keepdims=True)
@@ -594,7 +594,7 @@ def test_nn():
         xln = rng.standard_normal((2, 4, 5)).astype(np.float32)
         gln = np.ones((5,), dtype=np.float32)
         bln = np.zeros((5,), dtype=np.float32)
-        out = to_np(eng.layer_norm(make(xln, gpu), make(gln, gpu),
+        out = to_np(_C_engine.layer_norm(make(xln, gpu), make(gln, gpu),
                                    make(bln, gpu), 1e-5))
         mu = xln.mean(-1, keepdims=True)
         var = xln.var(-1, keepdims=True)
@@ -604,7 +604,7 @@ def test_nn():
         # rms_norm
         xrn = rng.standard_normal((2, 4)).astype(np.float32)
         grn = np.ones((4,), dtype=np.float32)
-        out = to_np(eng.rms_norm(make(xrn, gpu), make(grn, gpu), 1e-5))
+        out = to_np(_C_engine.rms_norm(make(xrn, gpu), make(grn, gpu), 1e-5))
         rms = np.sqrt((xrn ** 2).mean(-1, keepdims=True) + 1e-5)
         np_rn = xrn / rms * grn
         check(f"rms_norm[{dev}]", out, np_rn, tol=1e-3)
@@ -620,7 +620,7 @@ def test_nn_grad():
         W = rng.standard_normal((3, 5)).astype(np.float32) * 0.3
         bb = rng.standard_normal((3,)).astype(np.float32) * 0.1
         X = make(x, gpu, True); WW = make(W, gpu, True); BB = make(bb, gpu, True)
-        out = eng.sum(eng.linear(X, WW, BB), [], False)
+        out = _C_engine.sum(_C_engine.linear(X, WW, BB), [], False)
         gx, gw, gb = grad_of(out, [X, WW, BB])
         # expected: dx = ones(4,3) @ W = (4,5)
         ones_y = np.ones((4, 3), dtype=np.float32)
@@ -638,29 +638,29 @@ def test_random():
     section("random forward (CPU + GPU)")
     for dev in ("CPU", "GPU"):
         gpu = (dev == "GPU")
-        d = eng.Device.GPU if gpu else eng.Device.CPU
-        eng.default_generator().set_seed(42)
-        r = to_np(eng.rand([5000], eng.Dtype.F32, d, eng.default_generator()))
+        d = _C_engine.Device.GPU if gpu else _C_engine.Device.CPU
+        _C_engine.default_generator().set_seed(42)
+        r = to_np(_C_engine.rand([5000], _C_engine.Dtype.F32, d, _C_engine.default_generator()))
         check(f"rand mean ≈ 0.5[{dev}]",
               np.array(r.mean()), np.array(0.5), tol=0.05)
         check(f"rand range [0,1)[{dev}]",
               np.array([r.min() >= 0, r.max() < 1.0]),
               np.array([True, True]), exact=True)
 
-        eng.default_generator().set_seed(42)
-        rn = to_np(eng.randn([5000], eng.Dtype.F32, d, eng.default_generator()))
+        _C_engine.default_generator().set_seed(42)
+        rn = to_np(_C_engine.randn([5000], _C_engine.Dtype.F32, d, _C_engine.default_generator()))
         check(f"randn mean ≈ 0[{dev}]",
               np.array(rn.mean()), np.array(0.0), tol=0.1)
         check(f"randn std ≈ 1[{dev}]",
               np.array(rn.std()), np.array(1.0), tol=0.1)
 
     # Determinism: same seed → same draws on each device
-    eng.default_generator().set_seed(7)
-    a_cpu = to_np(eng.rand([1000], eng.Dtype.F32, eng.Device.CPU,
-                           eng.default_generator()))
-    eng.default_generator().set_seed(7)
-    a_gpu = to_np(eng.rand([1000], eng.Dtype.F32, eng.Device.GPU,
-                           eng.default_generator()))
+    _C_engine.default_generator().set_seed(7)
+    a_cpu = to_np(_C_engine.rand([1000], _C_engine.Dtype.F32, _C_engine.Device.CPU,
+                           _C_engine.default_generator()))
+    _C_engine.default_generator().set_seed(7)
+    a_gpu = to_np(_C_engine.rand([1000], _C_engine.Dtype.F32, _C_engine.Device.GPU,
+                           _C_engine.default_generator()))
     check("rand CPU↔GPU same seed", a_cpu, a_gpu, tol=1e-6)
 
 
@@ -677,17 +677,17 @@ def test_cpu_gpu_equivalence():
     # Element-wise
     A_cpu, A_gpu = make(a, False), make(a, True)
     B_cpu, B_gpu = make(b, False), make(b, True)
-    for name, fn in [("add", eng.add), ("sub", eng.sub), ("mul", eng.mul),
-                     ("maximum", eng.maximum), ("minimum", eng.minimum)]:
+    for name, fn in [("add", _C_engine.add), ("sub", _C_engine.sub), ("mul", _C_engine.mul),
+                     ("maximum", _C_engine.maximum), ("minimum", _C_engine.minimum)]:
         c = to_np(fn(A_cpu, B_cpu))
         g = to_np(fn(A_gpu, B_gpu))
         check(f"{name}: CPU≡GPU", c, g, tol=1e-5)
 
-    for name, fn in [("exp", eng.exp), ("log", lambda t: eng.log(make(np.abs(a) + 0.5))),
-                     ("sin", eng.sin), ("tanh", eng.tanh),
-                     ("sigmoid", eng.sigmoid), ("relu", eng.relu)]:
+    for name, fn in [("exp", _C_engine.exp), ("log", lambda t: _C_engine.log(make(np.abs(a) + 0.5))),
+                     ("sin", _C_engine.sin), ("tanh", _C_engine.tanh),
+                     ("sigmoid", _C_engine.sigmoid), ("relu", _C_engine.relu)]:
         if name == "log":
-            c = to_np(fn(A_cpu)); g = to_np(eng.log(make(np.abs(a) + 0.5, True)))
+            c = to_np(fn(A_cpu)); g = to_np(_C_engine.log(make(np.abs(a) + 0.5, True)))
         else:
             c = to_np(fn(A_cpu)); g = to_np(fn(A_gpu))
         check(f"{name}: CPU≡GPU", c, g, tol=1e-4)
@@ -695,13 +695,13 @@ def test_cpu_gpu_equivalence():
     # Matmul
     M1 = rng.standard_normal((3, 4)).astype(np.float32)
     M2 = rng.standard_normal((4, 5)).astype(np.float32)
-    c = to_np(eng.matmul(make(M1, False), make(M2, False)))
-    g = to_np(eng.matmul(make(M1, True), make(M2, True)))
+    c = to_np(_C_engine.matmul(make(M1, False), make(M2, False)))
+    g = to_np(_C_engine.matmul(make(M1, True), make(M2, True)))
     check("matmul: CPU≡GPU", c, g, tol=1e-4)
 
     # Reductions
-    for name, fn in [("sum", eng.sum), ("mean", eng.mean),
-                     ("max", eng.max), ("min", eng.min)]:
+    for name, fn in [("sum", _C_engine.sum), ("mean", _C_engine.mean),
+                     ("max", _C_engine.max), ("min", _C_engine.min)]:
         c = to_np(fn(A_cpu, [], False)); g = to_np(fn(A_gpu, [], False))
         check(f"{name}(all): CPU≡GPU", c, g, tol=1e-4)
 
@@ -714,26 +714,26 @@ def test_more_activations_grad():
         gpu = (dev == "GPU")
         # silu: f(x) = x * sigmoid(x); grad = sigmoid + x*sigmoid*(1-sigmoid)
         X = make(x, gpu, True)
-        out = eng.sum(eng.silu(X), [], False)
+        out = _C_engine.sum(_C_engine.silu(X), [], False)
         [g] = grad_of(out, [X])
         s = 1.0 / (1.0 + np.exp(-x))
         check(f"silu grad[{dev}]", g, s + x * s * (1.0 - s), tol=1e-4)
         # softplus: grad = sigmoid(x)
         X = make(x, gpu, True)
-        out = eng.sum(eng.softplus(X), [], False)
+        out = _C_engine.sum(_C_engine.softplus(X), [], False)
         [g] = grad_of(out, [X])
         check(f"softplus grad[{dev}]", g, s, tol=1e-4)
         # leaky_relu: grad = 1 if x>=0 else slope
         X = make(x, gpu, True)
-        out = eng.sum(eng.leaky_relu(X, 0.1), [], False)
+        out = _C_engine.sum(_C_engine.leaky_relu(X, 0.1), [], False)
         [g] = grad_of(out, [X])
         check(f"leaky_relu grad[{dev}]", g,
               np.where(x >= 0, 1.0, 0.1).astype(np.float32))
         # softmax along axis=-1: grad-of-sum is zero (softmax sums to 1)
         # so use a non-trivial loss: sum(softmax(x) * target)
         X = make(x, gpu, True)
-        sm = eng.softmax(X, -1)
-        out = eng.sum(sm, [], False)
+        sm = _C_engine.softmax(X, -1)
+        out = _C_engine.sum(sm, [], False)
         [g] = grad_of(out, [X])
         # d(sum(softmax))/dx = 0 since each row sums to 1
         check(f"softmax sum-grad ≈ 0[{dev}]", g, np.zeros_like(x), tol=1e-4)
@@ -751,7 +751,7 @@ def test_conv_pool_extra():
         w1[0, 0, 1] = 1.0
         b1 = np.zeros((1,), dtype=np.float32)
         check(f"conv1d (identity)[{dev}]",
-              to_np(eng.conv1d(make(x1, gpu), make(w1, gpu),
+              to_np(_C_engine.conv1d(make(x1, gpu), make(w1, gpu),
                                make(b1, gpu), 1, 1)),  # stride=1, pad=1
               x1)
 
@@ -761,7 +761,7 @@ def test_conv_pool_extra():
         w3[0, 0, 1, 1, 1] = 1.0
         b3 = np.zeros((1,), dtype=np.float32)
         check(f"conv3d (identity)[{dev}]",
-              to_np(eng.conv3d(make(x3, gpu), make(w3, gpu),
+              to_np(_C_engine.conv3d(make(x3, gpu), make(w3, gpu),
                                make(b3, gpu),
                                1, 1, 1,  # strides
                                1, 1, 1)),  # paddings
@@ -769,18 +769,18 @@ def test_conv_pool_extra():
 
         # max_pool1d
         xp1 = rng.standard_normal((1, 2, 6)).astype(np.float32)
-        out = to_np(eng.max_pool1d(make(xp1, gpu), 2, 2, 0))
+        out = to_np(_C_engine.max_pool1d(make(xp1, gpu), 2, 2, 0))
         np_out = np.maximum(xp1[..., 0::2], xp1[..., 1::2])
         check(f"max_pool1d[{dev}]", out, np_out)
 
         # avg_pool1d
-        out = to_np(eng.avg_pool1d(make(xp1, gpu), 2, 2, 0))
+        out = to_np(_C_engine.avg_pool1d(make(xp1, gpu), 2, 2, 0))
         np_avg = (xp1[..., 0::2] + xp1[..., 1::2]) / 2.0
         check(f"avg_pool1d[{dev}]", out, np_avg, tol=1e-4)
 
         # adaptive_avg_pool2d (output 2x2 from 4x4)
         xa = rng.standard_normal((1, 1, 4, 4)).astype(np.float32)
-        out = to_np(eng.adaptive_avg_pool2d(make(xa, gpu), 2, 2))
+        out = to_np(_C_engine.adaptive_avg_pool2d(make(xa, gpu), 2, 2))
         # Each output cell averages a 2x2 block
         np_out = np.zeros((1, 1, 2, 2), dtype=np.float32)
         for i in range(2):
@@ -789,7 +789,7 @@ def test_conv_pool_extra():
         check(f"adaptive_avg_pool2d[{dev}]", out, np_out, tol=1e-4)
 
         # adaptive_max_pool2d
-        out = to_np(eng.adaptive_max_pool2d(make(xa, gpu), 2, 2))
+        out = to_np(_C_engine.adaptive_max_pool2d(make(xa, gpu), 2, 2))
         np_out = np.zeros((1, 1, 2, 2), dtype=np.float32)
         for i in range(2):
             for j in range(2):
@@ -806,7 +806,7 @@ def test_norms_extra():
         xn = rng.standard_normal((2, 6, 4)).astype(np.float32)
         gamma = np.ones((6,), dtype=np.float32)
         beta = np.zeros((6,), dtype=np.float32)
-        out = to_np(eng.group_norm(make(xn, gpu), make(gamma, gpu),
+        out = to_np(_C_engine.group_norm(make(xn, gpu), make(gamma, gpu),
                                    make(beta, gpu), 2, 1e-5))
         # 2 groups of 3 channels each, normalize per (sample, group)
         groups = 2
@@ -825,7 +825,7 @@ def test_norms_extra():
         xb = rng.standard_normal((4, 3, 5)).astype(np.float32)
         gam = np.ones((3,), dtype=np.float32)
         bet = np.zeros((3,), dtype=np.float32)
-        out = to_np(eng.batch_norm1d(make(xb, gpu), make(gam, gpu),
+        out = to_np(_C_engine.batch_norm1d(make(xb, gpu), make(gam, gpu),
                                      make(bet, gpu), 1e-5))
         mu = xb.mean(axis=(0, 2), keepdims=True)
         var = xb.var(axis=(0, 2), keepdims=True)
@@ -839,19 +839,19 @@ def test_optim_steps():
     target = 5.0
     for opt_name in ("SGD", "Adam", "AdamW"):
         p_arr = np.array([1.0, 1.0, 1.0], dtype=np.float32)
-        p = eng.TensorImpl(p_arr.copy(), eng.Device.CPU, True)
+        p = _C_engine.TensorImpl(p_arr.copy(), _C_engine.Device.CPU, True)
         if opt_name == "SGD":
-            opt = eng.SGD([p], lr=0.1)
+            opt = _C_engine.SGD([p], lr=0.1)
         elif opt_name == "Adam":
-            opt = eng.Adam([p], lr=0.1)
+            opt = _C_engine.Adam([p], lr=0.1)
         else:
-            opt = eng.AdamW([p], lr=0.1)
+            opt = _C_engine.AdamW([p], lr=0.1)
         # 50 steps. Loss = sum((p - target)^2). Grad = 2*(p - target).
         for _ in range(50):
             p.zero_grad()
-            diff = eng.sub(p, eng.full([3], target, eng.Dtype.F32, eng.Device.CPU))
-            loss = eng.sum(eng.square(diff), [], False)
-            eng.engine_backward(loss)
+            diff = _C_engine.sub(p, _C_engine.full([3], target, _C_engine.Dtype.F32, _C_engine.Device.CPU))
+            loss = _C_engine.sum(_C_engine.square(diff), [], False)
+            _C_engine.engine_backward(loss)
             opt.step()
         final = np.array(p.data_as_python())
         # After 50 steps with lr=0.1, all 3 should be close to 5.0.
@@ -866,11 +866,11 @@ def test_view_grad():
     for dev in ("CPU", "GPU"):
         gpu = (dev == "GPU")
         X = make(x, gpu, True)
-        out = eng.sum(eng.reshape(X, [3, 4]), [], False)
+        out = _C_engine.sum(_C_engine.reshape(X, [3, 4]), [], False)
         [g] = grad_of(out, [X])
         check(f"reshape grad[{dev}]", g, np.ones_like(x))
         X = make(x, gpu, True)
-        out = eng.sum(eng.unsqueeze(X, 0), [], False)
+        out = _C_engine.sum(_C_engine.unsqueeze(X, 0), [], False)
         [g] = grad_of(out, [X])
         check(f"unsqueeze grad[{dev}]", g, np.ones_like(x))
 

--- a/scripts/verify_engine_full.py
+++ b/scripts/verify_engine_full.py
@@ -14,7 +14,7 @@ Pass criteria: max abs error < 1e-4 for float ops, exact for integer/bool.
 import sys
 import numpy as np
 
-from lucid._C import engine as eng
+from lucid._C import engine as _C_engine
 
 PASSED = 0
 FAILED = 0
@@ -25,7 +25,7 @@ def to_np(t):
 
 
 def from_np(arr, gpu=False):
-    return eng.TensorImpl(arr, eng.Device.GPU if gpu else eng.Device.CPU)
+    return _C_engine.TensorImpl(arr, _C_engine.Device.GPU if gpu else _C_engine.Device.CPU)
 
 
 def check(name, got, expected, tol=1e-4, exact=False):
@@ -64,131 +64,131 @@ def main():
     a = rng.standard_normal((4, 5)).astype(np.float32)
     b = rng.standard_normal((4, 5)).astype(np.float32)
     A, B = from_np(a), from_np(b)
-    check("add", to_np(eng.add(A, B)), a + b)
-    check("sub", to_np(eng.sub(A, B)), a - b)
-    check("mul", to_np(eng.mul(A, B)), a * b)
+    check("add", to_np(_C_engine.add(A, B)), a + b)
+    check("sub", to_np(_C_engine.sub(A, B)), a - b)
+    check("mul", to_np(_C_engine.mul(A, B)), a * b)
     b_safe = b + 2.0
-    check("div", to_np(eng.div(A, from_np(b_safe))), a / b_safe)
-    check("pow", to_np(eng.pow(from_np(np.abs(a) + 0.1), B)),
+    check("div", to_np(_C_engine.div(A, from_np(b_safe))), a / b_safe)
+    check("pow", to_np(_C_engine.pow(from_np(np.abs(a) + 0.1), B)),
           np.power(np.abs(a) + 0.1, b))
-    check("maximum", to_np(eng.maximum(A, B)), np.maximum(a, b))
-    check("minimum", to_np(eng.minimum(A, B)), np.minimum(a, b))
+    check("maximum", to_np(_C_engine.maximum(A, B)), np.maximum(a, b))
+    check("minimum", to_np(_C_engine.minimum(A, B)), np.minimum(a, b))
     M1 = rng.standard_normal((3, 4)).astype(np.float32)
     M2 = rng.standard_normal((4, 5)).astype(np.float32)
-    check("matmul", to_np(eng.matmul(from_np(M1), from_np(M2))), M1 @ M2)
+    check("matmul", to_np(_C_engine.matmul(from_np(M1), from_np(M2))), M1 @ M2)
 
     # ------------------ Unary math (formerly unary/) -------------------------
     section("Unary math (ufunc/Arith,Exp,Trig,Hyperbolic,Activation,ScalarParam,Discrete,Softmax)")
     x = rng.standard_normal((3, 4)).astype(np.float32)
     X = from_np(x)
-    check("neg",        to_np(eng.neg(X)),        -x)
-    check("abs",        to_np(eng.abs(X)),        np.abs(x))
-    check("sign",       to_np(eng.sign(X)),       np.sign(x))
-    check("reciprocal", to_np(eng.reciprocal(X)), 1.0 / x)
-    check("square",     to_np(eng.square(X)),     x * x)
-    check("cube",       to_np(eng.cube(X)),       x ** 3)
+    check("neg",        to_np(_C_engine.neg(X)),        -x)
+    check("abs",        to_np(_C_engine.abs(X)),        np.abs(x))
+    check("sign",       to_np(_C_engine.sign(X)),       np.sign(x))
+    check("reciprocal", to_np(_C_engine.reciprocal(X)), 1.0 / x)
+    check("square",     to_np(_C_engine.square(X)),     x * x)
+    check("cube",       to_np(_C_engine.cube(X)),       x ** 3)
 
     pos = np.abs(x) + 0.5
     P = from_np(pos)
-    check("exp",  to_np(eng.exp(X)),    np.exp(x))
-    check("log",  to_np(eng.log(P)),    np.log(pos))
-    check("log2", to_np(eng.log2(P)),   np.log2(pos))
-    check("sqrt", to_np(eng.sqrt(P)),   np.sqrt(pos))
+    check("exp",  to_np(_C_engine.exp(X)),    np.exp(x))
+    check("log",  to_np(_C_engine.log(P)),    np.log(pos))
+    check("log2", to_np(_C_engine.log2(P)),   np.log2(pos))
+    check("sqrt", to_np(_C_engine.sqrt(P)),   np.sqrt(pos))
 
-    check("sin", to_np(eng.sin(X)), np.sin(x))
-    check("cos", to_np(eng.cos(X)), np.cos(x))
-    check("tan", to_np(eng.tan(X)), np.tan(x), tol=1e-3)
+    check("sin", to_np(_C_engine.sin(X)), np.sin(x))
+    check("cos", to_np(_C_engine.cos(X)), np.cos(x))
+    check("tan", to_np(_C_engine.tan(X)), np.tan(x), tol=1e-3)
     bounded = np.clip(x, -0.9, 0.9).astype(np.float32)
     Bd = from_np(bounded)
-    check("arcsin", to_np(eng.arcsin(Bd)), np.arcsin(bounded))
-    check("arccos", to_np(eng.arccos(Bd)), np.arccos(bounded))
-    check("arctan", to_np(eng.arctan(X)),  np.arctan(x))
+    check("arcsin", to_np(_C_engine.arcsin(Bd)), np.arcsin(bounded))
+    check("arccos", to_np(_C_engine.arccos(Bd)), np.arccos(bounded))
+    check("arctan", to_np(_C_engine.arctan(X)),  np.arctan(x))
 
-    check("sinh", to_np(eng.sinh(X)), np.sinh(x))
-    check("cosh", to_np(eng.cosh(X)), np.cosh(x))
-    check("tanh", to_np(eng.tanh(X)), np.tanh(x))
+    check("sinh", to_np(_C_engine.sinh(X)), np.sinh(x))
+    check("cosh", to_np(_C_engine.cosh(X)), np.cosh(x))
+    check("tanh", to_np(_C_engine.tanh(X)), np.tanh(x))
 
     # Activations
-    check("relu",       to_np(eng.relu(X)),      np.maximum(x, 0.0))
-    check("sigmoid",    to_np(eng.sigmoid(X)),   1.0 / (1.0 + np.exp(-x)))
-    check("silu",       to_np(eng.silu(X)),      x * (1.0 / (1.0 + np.exp(-x))))
-    check("leaky_relu", to_np(eng.leaky_relu(X, 0.1)),
+    check("relu",       to_np(_C_engine.relu(X)),      np.maximum(x, 0.0))
+    check("sigmoid",    to_np(_C_engine.sigmoid(X)),   1.0 / (1.0 + np.exp(-x)))
+    check("silu",       to_np(_C_engine.silu(X)),      x * (1.0 / (1.0 + np.exp(-x))))
+    check("leaky_relu", to_np(_C_engine.leaky_relu(X, 0.1)),
           np.where(x >= 0, x, 0.1 * x))
-    check("softplus",   to_np(eng.softplus(X)),
+    check("softplus",   to_np(_C_engine.softplus(X)),
           np.log1p(np.exp(x)).astype(np.float32), tol=1e-3)
-    check("softmax(axis=-1)", to_np(eng.softmax(X, -1)),
+    check("softmax(axis=-1)", to_np(_C_engine.softmax(X, -1)),
           (lambda v: np.exp(v - v.max(-1, keepdims=True)) /
                      np.exp(v - v.max(-1, keepdims=True)).sum(-1, keepdims=True))(x))
 
     # Scalar-param
-    check("pow_scalar",  to_np(eng.pow_scalar(P, 2.0)), pos ** 2)
-    check("rpow_scalar", to_np(eng.rpow_scalar(2.0, X)), 2.0 ** x)
-    check("clip",        to_np(eng.clip(X, -0.5, 0.5)), np.clip(x, -0.5, 0.5))
+    check("pow_scalar",  to_np(_C_engine.pow_scalar(P, 2.0)), pos ** 2)
+    check("rpow_scalar", to_np(_C_engine.rpow_scalar(2.0, X)), 2.0 ** x)
+    check("clip",        to_np(_C_engine.clip(X, -0.5, 0.5)), np.clip(x, -0.5, 0.5))
 
     # Discrete
     half = (x * 4).astype(np.float32)
     H = from_np(half)
-    check("round", to_np(eng.round(H)), np.round(half))
-    check("floor", to_np(eng.floor(H)), np.floor(half))
-    check("ceil",  to_np(eng.ceil(H)),  np.ceil(half))
+    check("round", to_np(_C_engine.round(H)), np.round(half))
+    check("floor", to_np(_C_engine.floor(H)), np.floor(half))
+    check("ceil",  to_np(_C_engine.ceil(H)),  np.ceil(half))
     ints = np.array([5, 3, 0, -1], dtype=np.int32)
-    check("invert", to_np(eng.invert(from_np(ints))), ~ints, exact=True)
+    check("invert", to_np(_C_engine.invert(from_np(ints))), ~ints, exact=True)
 
     # ------------------ Reductions (formerly reduce/) ------------------------
     section("Reductions (ufunc/Reductions: sum/mean/prod/max/min)")
-    check("sum(all)",  to_np(eng.sum(X)),       x.sum())
-    check("sum(0)",    to_np(eng.sum(X, [0], False)), x.sum(0))
-    check("mean(1)",   to_np(eng.mean(X, [1], False)), x.mean(1))
-    check("prod(0)",   to_np(eng.prod(X, [0], False)), x.prod(0), tol=1e-3)
-    check("max(1)",    to_np(eng.max(X, [1], False)), x.max(1))
-    check("min(0)",    to_np(eng.min(X, [0], False)), x.min(0))
+    check("sum(all)",  to_np(_C_engine.sum(X)),       x.sum())
+    check("sum(0)",    to_np(_C_engine.sum(X, [0], False)), x.sum(0))
+    check("mean(1)",   to_np(_C_engine.mean(X, [1], False)), x.mean(1))
+    check("prod(0)",   to_np(_C_engine.prod(X, [0], False)), x.prod(0), tol=1e-3)
+    check("max(1)",    to_np(_C_engine.max(X, [1], False)), x.max(1))
+    check("min(0)",    to_np(_C_engine.min(X, [0], False)), x.min(0))
 
     # ------------------ Shape: permute family (now ufunc/Permute) ------------
     section("Permutation (ufunc/Permute: transpose/T/mT/swapaxes/permute)")
     M = rng.standard_normal((3, 4, 5)).astype(np.float32)
     Mt = from_np(M)
-    check("permute([2,0,1])", to_np(eng.permute(Mt, [2, 0, 1])),
+    check("permute([2,0,1])", to_np(_C_engine.permute(Mt, [2, 0, 1])),
           np.transpose(M, (2, 0, 1)))
-    check("transpose",  to_np(eng.transpose(Mt)),  np.transpose(M))
-    check("T",          to_np(eng.T(Mt)),          M.T)
-    check("mT",         to_np(eng.mT(Mt)),         np.swapaxes(M, -1, -2))
-    check("swapaxes",   to_np(eng.swapaxes(Mt, 0, 2)),
+    check("transpose",  to_np(_C_engine.transpose(Mt)),  np.transpose(M))
+    check("T",          to_np(_C_engine.T(Mt)),          M.T)
+    check("mT",         to_np(_C_engine.mT(Mt)),         np.swapaxes(M, -1, -2))
+    check("swapaxes",   to_np(_C_engine.swapaxes(Mt, 0, 2)),
           np.swapaxes(M, 0, 2))
 
     # ------------------ View family (now utils/View) ------------------------
     section("View family (utils/View: reshape/squeeze/unsqueeze)")
-    check("reshape", to_np(eng.reshape(Mt, [4, 15])), M.reshape(4, 15))
+    check("reshape", to_np(_C_engine.reshape(Mt, [4, 15])), M.reshape(4, 15))
     sq = rng.standard_normal((1, 3, 1, 4)).astype(np.float32)
     SQ = from_np(sq)
-    check("squeeze(0)",  to_np(eng.squeeze(SQ, 0)), np.squeeze(sq, 0))
-    check("squeeze_all", to_np(eng.squeeze_all(SQ)), sq.squeeze())
-    check("unsqueeze(0)", to_np(eng.unsqueeze(Mt, 0)),
+    check("squeeze(0)",  to_np(_C_engine.squeeze(SQ, 0)), np.squeeze(sq, 0))
+    check("squeeze_all", to_np(_C_engine.squeeze_all(SQ)), sq.squeeze())
+    check("unsqueeze(0)", to_np(_C_engine.unsqueeze(Mt, 0)),
           np.expand_dims(M, 0))
-    check("contiguous",   to_np(eng.contiguous(Mt)), M)
+    check("contiguous",   to_np(_C_engine.contiguous(Mt)), M)
 
     # ------------------ Random (now top-level random/) ----------------------
     section("Random (random/RandomOps)")
-    eng.default_generator().set_seed(42)
-    r1 = to_np(eng.rand([10000], eng.Dtype.F32, eng.Device.CPU,
-                        eng.default_generator()))
+    _C_engine.default_generator().set_seed(42)
+    r1 = to_np(_C_engine.rand([10000], _C_engine.Dtype.F32, _C_engine.Device.CPU,
+                        _C_engine.default_generator()))
     check("rand mean ≈ 0.5",
           np.array(r1.mean()), np.array(0.5), tol=0.05)
     check("rand range [0,1)",
           np.array([r1.min() >= 0, r1.max() < 1.0]),
           np.array([True, True]), exact=True)
-    eng.default_generator().set_seed(42)
-    r2 = to_np(eng.randn([10000], eng.Dtype.F32, eng.Device.CPU,
-                         eng.default_generator()))
+    _C_engine.default_generator().set_seed(42)
+    r2 = to_np(_C_engine.randn([10000], _C_engine.Dtype.F32, _C_engine.Device.CPU,
+                         _C_engine.default_generator()))
     check("randn mean ≈ 0", np.array(r2.mean()), np.array(0.0), tol=0.1)
     check("randn std  ≈ 1", np.array(r2.std()), np.array(1.0), tol=0.1)
 
     # Determinism: same seed → same draws
-    eng.default_generator().set_seed(7)
-    a1 = to_np(eng.rand([1000], eng.Dtype.F32, eng.Device.CPU,
-                        eng.default_generator()))
-    eng.default_generator().set_seed(7)
-    a2 = to_np(eng.rand([1000], eng.Dtype.F32, eng.Device.CPU,
-                        eng.default_generator()))
+    _C_engine.default_generator().set_seed(7)
+    a1 = to_np(_C_engine.rand([1000], _C_engine.Dtype.F32, _C_engine.Device.CPU,
+                        _C_engine.default_generator()))
+    _C_engine.default_generator().set_seed(7)
+    a2 = to_np(_C_engine.rand([1000], _C_engine.Dtype.F32, _C_engine.Device.CPU,
+                        _C_engine.default_generator()))
     check("rand determinism (CPU)", a1, a2, exact=True)
 
     # ------------------ NN (now top-level nn/) ------------------------------
@@ -197,7 +197,7 @@ def main():
     W = rng.standard_normal((3, 5)).astype(np.float32)
     bb = rng.standard_normal((3,)).astype(np.float32)
     xin = rng.standard_normal((4, 5)).astype(np.float32)
-    y_eng = to_np(eng.linear(from_np(xin), from_np(W), from_np(bb)))
+    y_eng = to_np(_C_engine.linear(from_np(xin), from_np(W), from_np(bb)))
     check("nn.linear", y_eng, xin @ W.T + bb, tol=1e-4)
 
     # Conv2d forward — sanity on identity-ish kernel
@@ -206,7 +206,7 @@ def main():
     wk = np.zeros((1, C, K, K), dtype=np.float32)
     wk[0, 0, 1, 1] = 1.0   # identity center tap
     bb_conv = np.zeros((1,), dtype=np.float32)
-    out_eng = to_np(eng.conv2d(from_np(xin), from_np(wk), from_np(bb_conv),
+    out_eng = to_np(_C_engine.conv2d(from_np(xin), from_np(wk), from_np(bb_conv),
                                1, 1, 1, 1))
     # Identity-tap with stride=1, pad=1 → output equals input.
     check("nn.conv2d (identity tap)", out_eng, xin)
@@ -214,12 +214,12 @@ def main():
     # ------------------ Optim (optim/) --------------------------------------
     section("Optim (optim/SGD step on a quadratic)")
     p_np = np.array([1.0, 2.0, 3.0], dtype=np.float32)
-    p_imp = eng.TensorImpl(p_np.copy(), eng.Device.CPU, True)
-    sgd = eng.SGD([p_imp], lr=0.1, momentum=0.0, dampening=0.0,
+    p_imp = _C_engine.TensorImpl(p_np.copy(), _C_engine.Device.CPU, True)
+    sgd = _C_engine.SGD([p_imp], lr=0.1, momentum=0.0, dampening=0.0,
                   weight_decay=0.0, nesterov=False)
     # Manually inject grad (= 2 * p, like d/dp of p^2)
     g = (2.0 * p_np).astype(np.float32)
-    p_imp.copy_from(eng.TensorImpl(p_np.copy(), eng.Device.CPU, False))
+    p_imp.copy_from(_C_engine.TensorImpl(p_np.copy(), _C_engine.Device.CPU, False))
     p_imp.zero_grad()
     # Simulate gradient by setting it via a different path: skip direct test;
     # just verify SGD object has correct lr property.

--- a/scripts/verify_full_coverage.py
+++ b/scripts/verify_full_coverage.py
@@ -14,7 +14,7 @@ import lucid
 import lucid.nn as nn
 import lucid.nn.functional as F
 from lucid._tensor import Tensor
-from lucid._C import engine as _E
+from lucid._C import engine as _C_engine
 
 
 _pass, _fail = 0, 0
@@ -29,7 +29,7 @@ def _check(name, ok, detail=""):
 
 
 def gpu_t(arr, rg=False):
-    return Tensor._wrap(_E.TensorImpl(arr, _E.Device.GPU, rg))
+    return Tensor._wrap(_C_engine.TensorImpl(arr, _C_engine.Device.GPU, rg))
 
 
 # === Top-level namespace exposure ===
@@ -166,9 +166,9 @@ print("\n=== GPU forward smoke ===")
 xn_gpu = gpu_t(xn)
 c_gpu = nn.Conv2d(3, 4, 3, padding=1)
 # Move conv weights to GPU
-c_gpu.weight._impl = _E.TensorImpl(c_gpu.weight.numpy(), _E.Device.GPU, True)
+c_gpu.weight._impl = _C_engine.TensorImpl(c_gpu.weight.numpy(), _C_engine.Device.GPU, True)
 if c_gpu.bias is not None:
-    c_gpu.bias._impl = _E.TensorImpl(c_gpu.bias.numpy(), _E.Device.GPU, True)
+    c_gpu.bias._impl = _C_engine.TensorImpl(c_gpu.bias.numpy(), _C_engine.Device.GPU, True)
 y_gpu = c_gpu(xn_gpu)
 _check("Conv2d GPU forward", y_gpu.shape == (2, 4, 8, 8))
 

--- a/scripts/verify_grid_sample_gpu.py
+++ b/scripts/verify_grid_sample_gpu.py
@@ -4,14 +4,14 @@ import sys
 
 import numpy as np
 
-from lucid._C import engine as eng
+from lucid._C import engine as _C_engine
 
 PASSED = 0
 FAILED = 0
 
 
 def make_tensor(data, device, requires_grad=False):
-    return eng.TensorImpl(np.asarray(data), device, requires_grad)
+    return _C_engine.TensorImpl(np.asarray(data), device, requires_grad)
 
 
 def data_np(tensor):
@@ -43,21 +43,21 @@ def check(name, got, expected, tol=1e-5):
 
 def run_case(name, x_np, grid_np, weight_np, mode, padding_mode,
              align_corners):
-    x_cpu = make_tensor(x_np, eng.Device.CPU, True)
-    grid_cpu = make_tensor(grid_np, eng.Device.CPU, True)
-    weight_cpu = make_tensor(weight_np, eng.Device.CPU)
-    out_cpu = eng.nn.grid_sample(
+    x_cpu = make_tensor(x_np, _C_engine.Device.CPU, True)
+    grid_cpu = make_tensor(grid_np, _C_engine.Device.CPU, True)
+    weight_cpu = make_tensor(weight_np, _C_engine.Device.CPU)
+    out_cpu = _C_engine.nn.grid_sample(
         x_cpu, grid_cpu, mode, padding_mode, align_corners)
-    loss_cpu = eng.sum(eng.mul(out_cpu, weight_cpu), [], False)
-    eng.engine_backward(loss_cpu, retain_graph=False)
+    loss_cpu = _C_engine.sum(_C_engine.mul(out_cpu, weight_cpu), [], False)
+    _C_engine.engine_backward(loss_cpu, retain_graph=False)
 
-    x_gpu = make_tensor(x_np, eng.Device.GPU, True)
-    grid_gpu = make_tensor(grid_np, eng.Device.GPU, True)
-    weight_gpu = make_tensor(weight_np, eng.Device.GPU)
-    out_gpu = eng.nn.grid_sample(
+    x_gpu = make_tensor(x_np, _C_engine.Device.GPU, True)
+    grid_gpu = make_tensor(grid_np, _C_engine.Device.GPU, True)
+    weight_gpu = make_tensor(weight_np, _C_engine.Device.GPU)
+    out_gpu = _C_engine.nn.grid_sample(
         x_gpu, grid_gpu, mode, padding_mode, align_corners)
-    loss_gpu = eng.sum(eng.mul(out_gpu, weight_gpu), [], False)
-    eng.engine_backward(loss_gpu, retain_graph=False)
+    loss_gpu = _C_engine.sum(_C_engine.mul(out_gpu, weight_gpu), [], False)
+    _C_engine.engine_backward(loss_gpu, retain_graph=False)
 
     check(f"{name} forward", data_np(out_gpu), data_np(out_cpu))
     check(f"{name} input grad", grad_np(x_gpu), grad_np(x_cpu))

--- a/scripts/verify_layout_unfold_gpu.py
+++ b/scripts/verify_layout_unfold_gpu.py
@@ -5,14 +5,14 @@ import sys
 
 import numpy as np
 
-from lucid._C import engine as eng
+from lucid._C import engine as _C_engine
 
 PASSED = 0
 FAILED = 0
 
 
 def make_tensor(data, device, requires_grad=False):
-    return eng.TensorImpl(np.asarray(data), device, requires_grad)
+    return _C_engine.TensorImpl(np.asarray(data), device, requires_grad)
 
 
 def data_np(tensor):
@@ -41,7 +41,7 @@ def check(name, got, expected, tol=1e-5):
 
 
 def backward_sum(out):
-    eng.engine_backward(eng.sum(out, [], False), retain_graph=False)
+    _C_engine.engine_backward(_C_engine.sum(out, [], False), retain_graph=False)
 
 
 def unfold_np(x, kernel, stride, pad, dilation):
@@ -108,19 +108,19 @@ def check_device(device):
     perm = [2, 0, 1]
     weight = np.arange(24, dtype=np.float32).reshape(4, 2, 3) / 7.0
     x = make_tensor(base, device, True)
-    y = eng.permute(x, perm)
+    y = _C_engine.permute(x, perm)
     check(f"permute forward ({device.name})", data_np(y),
           np.transpose(base, perm))
-    backward_sum(eng.mul(y, make_tensor(weight, device)))
+    backward_sum(_C_engine.mul(y, make_tensor(weight, device)))
     check(f"permute backward ({device.name})", grad_np(x),
           np.transpose(weight, np.argsort(perm)))
 
     base = np.arange(12, dtype=np.float32).reshape(3, 4)
     weight = np.arange(12, dtype=np.float32).reshape(4, 3) / 5.0
     x = make_tensor(base, device, True)
-    y = eng.contiguous(eng.transpose(x))
+    y = _C_engine.contiguous(_C_engine.transpose(x))
     check(f"contiguous transpose forward ({device.name})", data_np(y), base.T)
-    backward_sum(eng.mul(y, make_tensor(weight, device)))
+    backward_sum(_C_engine.mul(y, make_tensor(weight, device)))
     check(f"contiguous transpose backward ({device.name})", grad_np(x),
           weight.T)
 
@@ -132,16 +132,16 @@ def check_device(device):
     expected = unfold_np(x_np, kernel, stride, pad, dilation)
     weight = np.arange(expected.size, dtype=np.float32).reshape(expected.shape) / 13.0
     x = make_tensor(x_np, device, True)
-    y = eng.nn.unfold(x, kernel, stride, pad, dilation)
+    y = _C_engine.nn.unfold(x, kernel, stride, pad, dilation)
     check(f"unfold2d forward ({device.name})", data_np(y), expected)
-    backward_sum(eng.mul(y, make_tensor(weight, device)))
+    backward_sum(_C_engine.mul(y, make_tensor(weight, device)))
     check(f"unfold2d backward ({device.name})", grad_np(x),
           col2im_np(weight, x_np.shape, kernel, stride, pad, dilation))
 
 
 def main():
-    check_device(eng.Device.CPU)
-    check_device(eng.Device.GPU)
+    check_device(_C_engine.Device.CPU)
+    check_device(_C_engine.Device.GPU)
     print(f"\n--- TOTAL: {PASSED} passed, {FAILED} failed ---")
     return 0 if FAILED == 0 else 1
 

--- a/scripts/verify_phase4c.py
+++ b/scripts/verify_phase4c.py
@@ -17,7 +17,7 @@ Pass criteria: max abs error < 1e-4 for float ops, exact for integer/bool ops.
 import sys
 import numpy as np
 
-from lucid._C import engine as eng
+from lucid._C import engine as _C_engine
 from lucid._C.engine import linalg as la
 
 
@@ -26,7 +26,7 @@ def to_np(t):
 
 
 def from_np(arr, gpu=False):
-    return eng.TensorImpl(arr, eng.Device.GPU if gpu else eng.Device.CPU)
+    return _C_engine.TensorImpl(arr, _C_engine.Device.GPU if gpu else _C_engine.Device.CPU)
 
 
 PASSED = 0
@@ -66,21 +66,21 @@ def main():
 
     # ---- Creation ----
     section("Creation ops")
-    check("zeros", to_np(eng.zeros([2, 3])), np.zeros((2, 3), np.float32))
-    check("ones",  to_np(eng.ones([2, 3])),  np.ones((2, 3), np.float32))
-    check("full",  to_np(eng.full([2, 3], 3.14)),
+    check("zeros", to_np(_C_engine.zeros([2, 3])), np.zeros((2, 3), np.float32))
+    check("ones",  to_np(_C_engine.ones([2, 3])),  np.ones((2, 3), np.float32))
+    check("full",  to_np(_C_engine.full([2, 3], 3.14)),
           np.full((2, 3), 3.14, np.float32))
-    check("eye",   to_np(eng.eye(3, 4, 1)),
+    check("eye",   to_np(_C_engine.eye(3, 4, 1)),
           np.eye(3, 4, k=1, dtype=np.float32))
-    check("arange", to_np(eng.arange(0, 5, 1)),
+    check("arange", to_np(_C_engine.arange(0, 5, 1)),
           np.arange(0, 5, 1, np.float32))
-    check("linspace", to_np(eng.linspace(0, 1, 5)),
+    check("linspace", to_np(_C_engine.linspace(0, 1, 5)),
           np.linspace(0, 1, 5).astype(np.float32))
     v = from_np(np.arange(4, dtype=np.float32))
-    check("diag(1-D→2-D)", to_np(eng.diag(v, 0)),
+    check("diag(1-D→2-D)", to_np(_C_engine.diag(v, 0)),
           np.diag(np.arange(4, dtype=np.float32)))
     m = from_np(np.arange(9, dtype=np.float32).reshape(3, 3))
-    check("diag(2-D→1-D)", to_np(eng.diag(m, 0)),
+    check("diag(2-D→1-D)", to_np(_C_engine.diag(m, 0)),
           np.diag(np.arange(9, dtype=np.float32).reshape(3, 3)))
 
     # ---- Compare ----
@@ -88,97 +88,97 @@ def main():
     a = np.array([1.0, 2.0, 3.0], dtype=np.float32)
     b = np.array([2.0, 2.0, 2.0], dtype=np.float32)
     A = from_np(a); B = from_np(b)
-    check("equal",         to_np(eng.equal(A, B)),         a == b, exact=True)
-    check("not_equal",     to_np(eng.not_equal(A, B)),     a != b, exact=True)
-    check("greater",       to_np(eng.greater(A, B)),       a > b,  exact=True)
-    check("greater_equal", to_np(eng.greater_equal(A, B)), a >= b, exact=True)
-    check("less",          to_np(eng.less(A, B)),          a < b,  exact=True)
-    check("less_equal",    to_np(eng.less_equal(A, B)),    a <= b, exact=True)
+    check("equal",         to_np(_C_engine.equal(A, B)),         a == b, exact=True)
+    check("not_equal",     to_np(_C_engine.not_equal(A, B)),     a != b, exact=True)
+    check("greater",       to_np(_C_engine.greater(A, B)),       a > b,  exact=True)
+    check("greater_equal", to_np(_C_engine.greater_equal(A, B)), a >= b, exact=True)
+    check("less",          to_np(_C_engine.less(A, B)),          a < b,  exact=True)
+    check("less_equal",    to_np(_C_engine.less_equal(A, B)),    a <= b, exact=True)
 
     # ---- Bitwise ----
     section("Bitwise ops")
     ai = np.array([5, 3, 1, 0xff], dtype=np.int32)
     bi = np.array([3, 5, 7, 0x0f], dtype=np.int32)
     AI = from_np(ai); BI = from_np(bi)
-    check("bitwise_and", to_np(eng.bitwise_and(AI, BI)), ai & bi, exact=True)
-    check("bitwise_or",  to_np(eng.bitwise_or(AI, BI)),  ai | bi, exact=True)
-    check("bitwise_xor", to_np(eng.bitwise_xor(AI, BI)), ai ^ bi, exact=True)
+    check("bitwise_and", to_np(_C_engine.bitwise_and(AI, BI)), ai & bi, exact=True)
+    check("bitwise_or",  to_np(_C_engine.bitwise_or(AI, BI)),  ai | bi, exact=True)
+    check("bitwise_xor", to_np(_C_engine.bitwise_xor(AI, BI)), ai ^ bi, exact=True)
 
     # ---- Extra reductions / scans ----
     section("Extra reductions and scans")
     x = rng.standard_normal((3, 4)).astype(np.float32)
     X = from_np(x)
-    check("var(all)", to_np(eng.var(X)), np.var(x))
-    check("var(axis=0)", to_np(eng.var(X, [0], False)), np.var(x, axis=0))
-    check("var(axis=1)", to_np(eng.var(X, [1], False)), np.var(x, axis=1))
+    check("var(all)", to_np(_C_engine.var(X)), np.var(x))
+    check("var(axis=0)", to_np(_C_engine.var(X, [0], False)), np.var(x, axis=0))
+    check("var(axis=1)", to_np(_C_engine.var(X, [1], False)), np.var(x, axis=1))
     sq = rng.standard_normal((4, 4)).astype(np.float32)
     SQ = from_np(sq)
-    check("trace(2-D)", to_np(eng.trace(SQ)), np.trace(sq))
-    check("cumsum(axis=0)",  to_np(eng.cumsum(X, 0)),  np.cumsum(x, axis=0))
-    check("cumsum(axis=-1)", to_np(eng.cumsum(X, -1)), np.cumsum(x, axis=-1))
-    check("cumprod(axis=0)", to_np(eng.cumprod(X, 0)), np.cumprod(x, axis=0))
+    check("trace(2-D)", to_np(_C_engine.trace(SQ)), np.trace(sq))
+    check("cumsum(axis=0)",  to_np(_C_engine.cumsum(X, 0)),  np.cumsum(x, axis=0))
+    check("cumsum(axis=-1)", to_np(_C_engine.cumsum(X, -1)), np.cumsum(x, axis=-1))
+    check("cumprod(axis=0)", to_np(_C_engine.cumprod(X, 0)), np.cumprod(x, axis=0))
 
     # ---- Dot / inner / outer (CPU 1-D and 2-D) ----
     section("Dot, inner, outer")
     u = rng.standard_normal(5).astype(np.float32)
     v = rng.standard_normal(5).astype(np.float32)
     U = from_np(u); V = from_np(v)
-    check("dot(1-D)", to_np(eng.dot(U, V)), np.dot(u, v))
+    check("dot(1-D)", to_np(_C_engine.dot(U, V)), np.dot(u, v))
     M1 = rng.standard_normal((4, 5)).astype(np.float32)
     M2 = rng.standard_normal((5, 3)).astype(np.float32)
-    check("dot(2-D, 2-D)", to_np(eng.dot(from_np(M1), from_np(M2))),
+    check("dot(2-D, 2-D)", to_np(_C_engine.dot(from_np(M1), from_np(M2))),
           np.dot(M1, M2))
-    check("inner(1-D)", to_np(eng.inner(U, V)), np.inner(u, v))
-    check("outer", to_np(eng.outer(U, V)), np.outer(u, v))
+    check("inner(1-D)", to_np(_C_engine.inner(U, V)), np.inner(u, v))
+    check("outer", to_np(_C_engine.outer(U, V)), np.outer(u, v))
 
     # ---- Shape utils ----
     section("Shape utilities")
     a2 = rng.standard_normal((2, 3)).astype(np.float32)
     b2 = rng.standard_normal((2, 3)).astype(np.float32)
     A2 = from_np(a2); B2 = from_np(b2)
-    check("concat(axis=0)", to_np(eng.concatenate([A2, B2], 0)),
+    check("concat(axis=0)", to_np(_C_engine.concatenate([A2, B2], 0)),
           np.concatenate([a2, b2], 0))
-    check("concat(axis=1)", to_np(eng.concatenate([A2, B2], 1)),
+    check("concat(axis=1)", to_np(_C_engine.concatenate([A2, B2], 1)),
           np.concatenate([a2, b2], 1))
-    check("stack(axis=0)", to_np(eng.stack([A2, B2], 0)),
+    check("stack(axis=0)", to_np(_C_engine.stack([A2, B2], 0)),
           np.stack([a2, b2], 0))
 
-    splits_cpp = eng.split(A2, 3, axis=1)
+    splits_cpp = _C_engine.split(A2, 3, axis=1)
     splits_np = np.split(a2, 3, axis=1)
     for i, (sc, sn) in enumerate(zip(splits_cpp, splits_np)):
         check(f"split[{i}]", to_np(sc), sn)
 
-    check("repeat(axis=0)", to_np(eng.repeat(A2, 2, axis=0)),
+    check("repeat(axis=0)", to_np(_C_engine.repeat(A2, 2, axis=0)),
           np.repeat(a2, 2, axis=0))
 
     flat3 = rng.standard_normal((2, 3, 4)).astype(np.float32)
     F3 = from_np(flat3)
-    check("flatten(0,-1)", to_np(eng.flatten(F3, 0, -1)), flat3.reshape(-1))
+    check("flatten(0,-1)", to_np(_C_engine.flatten(F3, 0, -1)), flat3.reshape(-1))
     check("flatten(1, 2)",
-          to_np(eng.flatten(F3, 1, 2)), flat3.reshape(2, 12))
+          to_np(_C_engine.flatten(F3, 1, 2)), flat3.reshape(2, 12))
 
     sq2 = np.arange(9, dtype=np.float32).reshape(3, 3)
     SQ2 = from_np(sq2)
-    check("tril(0)", to_np(eng.tril(SQ2, 0)), np.tril(sq2, 0))
-    check("tril(1)", to_np(eng.tril(SQ2, 1)), np.tril(sq2, 1))
-    check("triu(-1)", to_np(eng.triu(SQ2, -1)), np.triu(sq2, -1))
+    check("tril(0)", to_np(_C_engine.tril(SQ2, 0)), np.tril(sq2, 0))
+    check("tril(1)", to_np(_C_engine.tril(SQ2, 1)), np.tril(sq2, 1))
+    check("triu(-1)", to_np(_C_engine.triu(SQ2, -1)), np.triu(sq2, -1))
 
     bcast_in = rng.standard_normal((1, 4)).astype(np.float32)
     BC = from_np(bcast_in)
-    check("broadcast_to", to_np(eng.broadcast_to(BC, [3, 4])),
+    check("broadcast_to", to_np(_C_engine.broadcast_to(BC, [3, 4])),
           np.broadcast_to(bcast_in, (3, 4)))
 
-    check("argmax(axis=1)", to_np(eng.argmax(A2, axis=1, keepdims=False)),
+    check("argmax(axis=1)", to_np(_C_engine.argmax(A2, axis=1, keepdims=False)),
           np.argmax(a2, axis=1).astype(np.int64), exact=True)
-    check("argmin(axis=0)", to_np(eng.argmin(A2, axis=0, keepdims=False)),
+    check("argmin(axis=0)", to_np(_C_engine.argmin(A2, axis=0, keepdims=False)),
           np.argmin(a2, axis=0).astype(np.int64), exact=True)
 
     cond = (a2 > 0).astype(np.uint8)
     COND = from_np(cond)
-    check("where", to_np(eng.where(COND, A2, B2)), np.where(cond, a2, b2))
+    check("where", to_np(_C_engine.where(COND, A2, B2)), np.where(cond, a2, b2))
     mask = (a2 > 0).astype(np.uint8)
     MASK = from_np(mask)
-    check("masked_fill", to_np(eng.masked_fill(A2, MASK, 9.0)),
+    check("masked_fill", to_np(_C_engine.masked_fill(A2, MASK, 9.0)),
           np.where(mask, 9.0, a2))
 
     # ---- Linalg (GPU only) ----

--- a/scripts/verify_phase4d_cpu.py
+++ b/scripts/verify_phase4d_cpu.py
@@ -3,7 +3,7 @@
 import sys
 import numpy as np
 
-from lucid._C import engine as eng
+from lucid._C import engine as _C_engine
 
 PASSED = 0
 FAILED = 0
@@ -14,7 +14,7 @@ def to_np(t):
 
 
 def from_np(arr):
-    return eng.TensorImpl(arr)
+    return _C_engine.TensorImpl(arr)
 
 
 def check(name, got, expected, tol=1e-4, exact=False):
@@ -50,29 +50,29 @@ def main():
 
     section("split_at (CPU)")
     a = np.arange(20, dtype=np.float32).reshape(4, 5)
-    parts = eng.split_at(from_np(a), [2], axis=1)
+    parts = _C_engine.split_at(from_np(a), [2], axis=1)
     np_parts = np.split(a, [2], axis=1)
     for i, (p, np_p) in enumerate(zip(parts, np_parts)):
         check(f"split_at[{i}]", to_np(p), np_p)
 
     section("tile (CPU)")
     x = np.arange(6, dtype=np.float32).reshape(2, 3)
-    check("tile([2,3])", to_np(eng.tile(from_np(x), [2, 3])),
+    check("tile([2,3])", to_np(_C_engine.tile(from_np(x), [2, 3])),
           np.tile(x, (2, 3)))
 
     section("pad (CPU)")
     p = rng.standard_normal((2, 3)).astype(np.float32)
-    check("pad constant=0", to_np(eng.pad(from_np(p), [(1, 1), (2, 0)], 0.0)),
+    check("pad constant=0", to_np(_C_engine.pad(from_np(p), [(1, 1), (2, 0)], 0.0)),
           np.pad(p, [(1, 1), (2, 0)], constant_values=0.0))
-    check("pad constant=7", to_np(eng.pad(from_np(p), [(0, 1), (1, 2)], 7.0)),
+    check("pad constant=7", to_np(_C_engine.pad(from_np(p), [(0, 1), (1, 2)], 7.0)),
           np.pad(p, [(0, 1), (1, 2)], constant_values=7.0))
 
     section("roll (CPU)")
     r = np.arange(12, dtype=np.float32).reshape(3, 4)
     check("roll(shift=2,axis=1)",
-          to_np(eng.roll(from_np(r), [2], [1])), np.roll(r, 2, axis=1))
+          to_np(_C_engine.roll(from_np(r), [2], [1])), np.roll(r, 2, axis=1))
     check("roll(multi-axis)",
-          to_np(eng.roll(from_np(r), [1, 2], [0, 1])),
+          to_np(_C_engine.roll(from_np(r), [1, 2], [0, 1])),
           np.roll(r, (1, 2), axis=(0, 1)))
 
     section("gather (CPU)")
@@ -80,46 +80,46 @@ def main():
     idx = np.array([[2, 0, 1, 4, 3], [1, 1, 0, 2, 4], [4, 3, 2, 1, 0]],
                    dtype=np.int32)
     check("gather(axis=1)",
-          to_np(eng.gather(from_np(g), from_np(idx), 1)),
+          to_np(_C_engine.gather(from_np(g), from_np(idx), 1)),
           np.take_along_axis(g, idx.astype(np.int64), axis=1))
 
     section("diagonal (CPU)")
     d3 = rng.standard_normal((4, 5)).astype(np.float32)
     check("diagonal(offset=0)",
-          to_np(eng.diagonal(from_np(d3), 0, -2, -1)),
+          to_np(_C_engine.diagonal(from_np(d3), 0, -2, -1)),
           np.diagonal(d3, 0, -2, -1))
     check("diagonal(offset=1)",
-          to_np(eng.diagonal(from_np(d3), 1, -2, -1)),
+          to_np(_C_engine.diagonal(from_np(d3), 1, -2, -1)),
           np.diagonal(d3, 1, -2, -1))
     d4 = rng.standard_normal((2, 4, 5)).astype(np.float32)
     check("diagonal(batched)",
-          to_np(eng.diagonal(from_np(d4), 0, -2, -1)),
+          to_np(_C_engine.diagonal(from_np(d4), 0, -2, -1)),
           np.diagonal(d4, 0, -2, -1))
 
     section("sort / argsort (CPU)")
     s = rng.standard_normal((3, 5)).astype(np.float32)
     check("sort(axis=1)",
-          to_np(eng.sort(from_np(s), 1)), np.sort(s, axis=1))
+          to_np(_C_engine.sort(from_np(s), 1)), np.sort(s, axis=1))
     check("sort(axis=0)",
-          to_np(eng.sort(from_np(s), 0)), np.sort(s, axis=0))
+          to_np(_C_engine.sort(from_np(s), 0)), np.sort(s, axis=0))
     check("argsort(axis=1)",
-          to_np(eng.argsort(from_np(s), 1)).astype(np.int64),
+          to_np(_C_engine.argsort(from_np(s), 1)).astype(np.int64),
           np.argsort(s, axis=1).astype(np.int64), exact=True)
 
     section("topk (CPU)")
     tk = np.array([[1.0, 5.0, 2.0, 8.0, 3.0]], dtype=np.float32)
-    out = to_np(eng.topk(from_np(tk), 3, 1))
+    out = to_np(_C_engine.topk(from_np(tk), 3, 1))
     expected = np.sort(tk, axis=1)[:, ::-1][:, :3]
     check("topk(k=3)", out, expected)
 
     section("meshgrid (CPU)")
     xv = np.array([1.0, 2.0, 3.0], dtype=np.float32)
     yv = np.array([10.0, 20.0], dtype=np.float32)
-    a_eng, b_eng = eng.meshgrid([from_np(xv), from_np(yv)], indexing_xy=False)
+    a_eng, b_eng = _C_engine.meshgrid([from_np(xv), from_np(yv)], indexing_xy=False)
     a_np, b_np = np.meshgrid(xv, yv, indexing="ij")
     check("meshgrid ij A", to_np(a_eng), a_np)
     check("meshgrid ij B", to_np(b_eng), b_np)
-    a2_eng, b2_eng = eng.meshgrid([from_np(xv), from_np(yv)], indexing_xy=True)
+    a2_eng, b2_eng = _C_engine.meshgrid([from_np(xv), from_np(yv)], indexing_xy=True)
     a2_np, b2_np = np.meshgrid(xv, yv, indexing="xy")
     check("meshgrid xy A", to_np(a2_eng), a2_np)
     check("meshgrid xy B", to_np(b2_eng), b2_np)
@@ -128,12 +128,12 @@ def main():
     A = rng.standard_normal((3, 4, 5)).astype(np.float32)
     B = rng.standard_normal((5, 4, 6)).astype(np.float32)
     check("tensordot axes_a=[2],axes_b=[0]",
-          to_np(eng.tensordot(from_np(A), from_np(B), [2], [0])),
+          to_np(_C_engine.tensordot(from_np(A), from_np(B), [2], [0])),
           np.tensordot(A, B, axes=([2], [0])), tol=1e-3)
     A2 = rng.standard_normal((2, 3, 4, 5)).astype(np.float32)
     B2 = rng.standard_normal((4, 5, 6)).astype(np.float32)
     check("tensordot axes_a=[2,3],axes_b=[0,1]",
-          to_np(eng.tensordot(from_np(A2), from_np(B2), [2, 3], [0, 1])),
+          to_np(_C_engine.tensordot(from_np(A2), from_np(B2), [2, 3], [0, 1])),
           np.tensordot(A2, B2, axes=([2, 3], [0, 1])), tol=1e-3)
 
     print(f"\n--- TOTAL: {PASSED} passed, {FAILED} failed ---")

--- a/scripts/verify_phase4d_grad.py
+++ b/scripts/verify_phase4d_grad.py
@@ -16,7 +16,7 @@ The backward formulas under test:
 import sys
 import numpy as np
 
-from lucid._C import engine as eng
+from lucid._C import engine as _C_engine
 
 PASSED = 0
 FAILED = 0
@@ -27,14 +27,14 @@ def to_np(t):
 
 
 def make_leaf(arr, requires_grad=True):
-    return eng.TensorImpl(arr.copy(), eng.Device.CPU, requires_grad)
+    return _C_engine.TensorImpl(arr.copy(), _C_engine.Device.CPU, requires_grad)
 
 
 def grad_of(out, leaves):
     """Returns each leaf's gradient as a numpy array after engine_backward."""
     for leaf in leaves:
         leaf.zero_grad()
-    eng.engine_backward(out, retain_graph=False)
+    _C_engine.engine_backward(out, retain_graph=False)
     return [np.array(leaf.grad_as_python()) for leaf in leaves]
 
 
@@ -83,13 +83,13 @@ def main():
     section("var backward")
     x = rng.standard_normal((3, 4)).astype(np.float32) * 0.5
     leaf = make_leaf(x)
-    out = eng.var(leaf, [], False)  # scalar variance
+    out = _C_engine.var(leaf, [], False)  # scalar variance
     [g] = grad_of(out, [leaf])
     fd = fd_grad(lambda v: np.var(v), x)
     check("var(all)", g, fd)
 
     leaf = make_leaf(x)
-    out = eng.sum(eng.var(leaf, [1], False), [], False)  # sum-reduce so scalar
+    out = _C_engine.sum(_C_engine.var(leaf, [1], False), [], False)  # sum-reduce so scalar
     [g] = grad_of(out, [leaf])
     fd = fd_grad(lambda v: np.var(v, axis=1).sum(), x)
     check("var(axis=1)", g, fd)
@@ -97,7 +97,7 @@ def main():
     section("trace backward")
     M = rng.standard_normal((4, 4)).astype(np.float32) * 0.5
     leaf = make_leaf(M)
-    out = eng.trace(leaf)  # scalar
+    out = _C_engine.trace(leaf)  # scalar
     [g] = grad_of(out, [leaf])
     fd = fd_grad(lambda v: float(np.trace(v)), M)
     check("trace(2-D)", g, fd)
@@ -105,13 +105,13 @@ def main():
     section("cumsum backward")
     x = rng.standard_normal((3, 5)).astype(np.float32) * 0.5
     leaf = make_leaf(x)
-    out = eng.sum(eng.cumsum(leaf, 1), [], False)
+    out = _C_engine.sum(_C_engine.cumsum(leaf, 1), [], False)
     [g] = grad_of(out, [leaf])
     fd = fd_grad(lambda v: np.cumsum(v, axis=1).sum(), x)
     check("cumsum(axis=1)", g, fd)
 
     leaf = make_leaf(x)
-    out = eng.sum(eng.cumsum(leaf, 0), [], False)
+    out = _C_engine.sum(_C_engine.cumsum(leaf, 0), [], False)
     [g] = grad_of(out, [leaf])
     fd = fd_grad(lambda v: np.cumsum(v, axis=0).sum(), x)
     check("cumsum(axis=0)", g, fd)
@@ -121,7 +121,7 @@ def main():
     b = rng.standard_normal(5).astype(np.float32) * 0.5
     la = make_leaf(a)
     lb = make_leaf(b)
-    out = eng.dot(la, lb)
+    out = _C_engine.dot(la, lb)
     ga, gb = grad_of(out, [la, lb])
     fd_a = fd_grad(lambda v: float(np.dot(v, b)), a)
     fd_b = fd_grad(lambda v: float(np.dot(a, v)), b)
@@ -133,7 +133,7 @@ def main():
     B = rng.standard_normal((4, 2)).astype(np.float32) * 0.5
     lA = make_leaf(A)
     lB = make_leaf(B)
-    out = eng.sum(eng.dot(lA, lB), [], False)
+    out = _C_engine.sum(_C_engine.dot(lA, lB), [], False)
     gA, gB = grad_of(out, [lA, lB])
     fd_A = fd_grad(lambda v: float(np.dot(v, B).sum()), A)
     fd_B = fd_grad(lambda v: float(np.dot(A, v).sum()), B)
@@ -145,7 +145,7 @@ def main():
     b = rng.standard_normal(3).astype(np.float32) * 0.5
     la = make_leaf(a)
     lb = make_leaf(b)
-    out = eng.sum(eng.outer(la, lb), [], False)
+    out = _C_engine.sum(_C_engine.outer(la, lb), [], False)
     ga, gb = grad_of(out, [la, lb])
     fd_a = fd_grad(lambda v: float(np.outer(v, b).sum()), a)
     fd_b = fd_grad(lambda v: float(np.outer(a, v).sum()), b)

--- a/scripts/verify_phase4f.py
+++ b/scripts/verify_phase4f.py
@@ -7,7 +7,7 @@
 import sys
 import numpy as np
 
-from lucid._C import engine as eng
+from lucid._C import engine as _C_engine
 
 PASSED = 0
 FAILED = 0
@@ -18,7 +18,7 @@ def to_np(t):
 
 
 def from_np(arr, requires_grad=False):
-    return eng.TensorImpl(arr.copy(), eng.Device.CPU, requires_grad)
+    return _C_engine.TensorImpl(arr.copy(), _C_engine.Device.CPU, requires_grad)
 
 
 def check(name, got, expected, tol=1e-4, exact=False):
@@ -56,16 +56,16 @@ def main():
     a = np.array([7.0, 8.0, 9.0, -3.0], dtype=np.float32)
     b = np.array([2.0, 3.0, 4.0, 2.0],  dtype=np.float32)
     check("floordiv f32",
-          to_np(eng.floordiv(from_np(a), from_np(b))),
+          to_np(_C_engine.floordiv(from_np(a), from_np(b))),
           np.floor(a / b).astype(np.int64), exact=True)
 
     section("_like family")
     x = rng.standard_normal((2, 3)).astype(np.float32)
     X = from_np(x)
-    z = eng.zeros_like(X)
-    o = eng.ones_like(X)
-    e = eng.empty_like(X)
-    f = eng.full_like(X, 7.0)
+    z = _C_engine.zeros_like(X)
+    o = _C_engine.ones_like(X)
+    e = _C_engine.empty_like(X)
+    f = _C_engine.full_like(X, 7.0)
     check("zeros_like shape", to_np(z), np.zeros_like(x))
     check("ones_like sum", float(to_np(o).sum()), float(np.ones_like(x).sum()))
     check("empty_like shape", np.array(e.shape), np.array(x.shape), exact=True)
@@ -74,25 +74,25 @@ def main():
     section("expand_dims, ravel")
     x = rng.standard_normal((3, 4)).astype(np.float32)
     X = from_np(x)
-    check("expand_dims(0)", to_np(eng.expand_dims(X, 0)), x[None, ...])
-    check("expand_dims(-1)", to_np(eng.expand_dims(X, -1)), x[..., None])
-    check("ravel", to_np(eng.ravel(X)), x.reshape(-1))
+    check("expand_dims(0)", to_np(_C_engine.expand_dims(X, 0)), x[None, ...])
+    check("expand_dims(-1)", to_np(_C_engine.expand_dims(X, -1)), x[..., None])
+    check("ravel", to_np(_C_engine.ravel(X)), x.reshape(-1))
 
     section("nonzero")
     nz = np.array([[0, 1, 0], [2, 0, 3]], dtype=np.float32)
     NZ = from_np(nz)
-    out = to_np(eng.nonzero(NZ))
+    out = to_np(_C_engine.nonzero(NZ))
     expected = np.argwhere(nz).astype(np.int64)
     check("nonzero", out, expected, exact=True)
 
     section("unique")
     u = np.array([3, 1, 2, 1, 4, 3, 5, 2], dtype=np.int32)
-    out = to_np(eng.unique(from_np(u)))
+    out = to_np(_C_engine.unique(from_np(u)))
     check("unique", out, np.array([1, 2, 3, 4, 5], dtype=np.int32), exact=True)
 
     section("histogram")
     x = rng.standard_normal(1000).astype(np.float32)
-    counts_eng, edges_eng = eng.histogram(from_np(x), 10, -3.0, 3.0, False)
+    counts_eng, edges_eng = _C_engine.histogram(from_np(x), 10, -3.0, 3.0, False)
     counts_np, edges_np = np.histogram(x, bins=10, range=(-3.0, 3.0))
     check("histogram counts",
           to_np(counts_eng).astype(np.int64),
@@ -100,7 +100,7 @@ def main():
     check("histogram edges", to_np(edges_eng), edges_np.astype(np.float64),
           tol=1e-6)
 
-    counts_eng, edges_eng = eng.histogram2d(
+    counts_eng, edges_eng = _C_engine.histogram2d(
         from_np(x[:500]), from_np(x[500:1000]), 5, 5,
         -3.0, 3.0, -3.0, 3.0, False)
     counts_np, ex_np, ey_np = np.histogram2d(
@@ -112,7 +112,7 @@ def main():
 
     # histogramdd
     multi = rng.standard_normal((500, 2)).astype(np.float32)
-    counts_eng, _ = eng.histogramdd(
+    counts_eng, _ = _C_engine.histogramdd(
         from_np(multi), [4, 4], [(-3.0, 3.0), (-3.0, 3.0)], False)
     counts_np, _ = np.histogramdd(multi, bins=[4, 4],
                                    range=[[-3.0, 3.0], [-3.0, 3.0]])
@@ -124,39 +124,39 @@ def main():
     a = rng.standard_normal((3, 4)).astype(np.float32)
     b = rng.standard_normal((3, 4)).astype(np.float32)
     A = from_np(a); B = from_np(b)
-    eng.add_(A, B)
+    _C_engine.add_(A, B)
     check("add_ result", to_np(A), a + b)
     A = from_np(a)
-    eng.sub_(A, B)
+    _C_engine.sub_(A, B)
     check("sub_ result", to_np(A), a - b)
     A = from_np(a)
-    eng.mul_(A, B)
+    _C_engine.mul_(A, B)
     check("mul_ result", to_np(A), a * b)
 
     section("in-place unary (neg_, exp_, square_, sqrt_, etc.)")
     x = rng.standard_normal((2, 3)).astype(np.float32)
     X = from_np(x)
-    eng.neg_(X)
+    _C_engine.neg_(X)
     check("neg_", to_np(X), -x)
     X = from_np(np.abs(x) + 0.5)
-    eng.sqrt_(X)
+    _C_engine.sqrt_(X)
     check("sqrt_", to_np(X), np.sqrt(np.abs(x) + 0.5))
     X = from_np(x)
-    eng.square_(X)
+    _C_engine.square_(X)
     check("square_", to_np(X), x * x)
     X = from_np(x)
-    eng.exp_(X)
+    _C_engine.exp_(X)
     check("exp_", to_np(X), np.exp(x))
     X = from_np(x)
-    eng.tanh_(X)
+    _C_engine.tanh_(X)
     check("tanh_", to_np(X), np.tanh(x))
 
     section("in-place version bumping")
     A = from_np(rng.standard_normal((3,)).astype(np.float32), requires_grad=False)
     v0 = A.version
-    eng.neg_(A)
+    _C_engine.neg_(A)
     v1 = A.version
-    eng.exp_(A)
+    _C_engine.exp_(A)
     v2 = A.version
     check("version bumps", np.array([v0, v1, v2]),
           np.array([0, 1, 2], dtype=np.int64), exact=True)

--- a/scripts/verify_phase6_9.py
+++ b/scripts/verify_phase6_9.py
@@ -7,14 +7,14 @@ import numpy as np
 
 import lucid
 from lucid._tensor import Tensor
-from lucid._C import engine as _E
+from lucid._C import engine as _C_engine
 from lucid.ops.bfunc import multiply
 from lucid.ops.ufunc import sum as sum_op
 import lucid.nn.functional as F
 
 
 def gpu_t(arr: np.ndarray, requires_grad: bool = False) -> Tensor:
-    return Tensor._wrap(_E.TensorImpl(arr, _E.Device.GPU, requires_grad))
+    return Tensor._wrap(_C_engine.TensorImpl(arr, _C_engine.Device.GPU, requires_grad))
 
 
 _pass = 0

--- a/scripts/verify_utils_grad.py
+++ b/scripts/verify_utils_grad.py
@@ -4,14 +4,14 @@ import sys
 
 import numpy as np
 
-from lucid._C import engine as eng
+from lucid._C import engine as _C_engine
 
 PASSED = 0
 FAILED = 0
 
 
 def make_tensor(data, device, requires_grad=False):
-    return eng.TensorImpl(np.asarray(data), device, requires_grad)
+    return _C_engine.TensorImpl(np.asarray(data), device, requires_grad)
 
 
 def grad_np(tensor):
@@ -38,7 +38,7 @@ def check(name, got, expected, tol=1e-5):
 
 
 def backward_sum(out):
-    eng.engine_backward(eng.sum(out, [], False), retain_graph=False)
+    _C_engine.engine_backward(_C_engine.sum(out, [], False), retain_graph=False)
 
 
 def check_where(device):
@@ -49,7 +49,7 @@ def check_where(device):
     x = make_tensor(x_np, device, True)
     y = make_tensor(y_np, device, True)
 
-    backward_sum(eng.where(cond, x, y))
+    backward_sum(_C_engine.where(cond, x, y))
     check(f"where x ({device.name})", grad_np(x), cond_np.astype(np.float32))
     check(f"where y ({device.name})", grad_np(y), (~cond_np).astype(np.float32))
 
@@ -60,7 +60,7 @@ def check_masked_fill(device):
     a = make_tensor(np.arange(6, dtype=np.float32).reshape(2, 3), device, True)
     mask = make_tensor(mask_np, device)
 
-    backward_sum(eng.masked_fill(a, mask, -7.0))
+    backward_sum(_C_engine.masked_fill(a, mask, -7.0))
     check(f"masked_fill ({device.name})", grad_np(a),
           (~mask_np).astype(np.float32))
 
@@ -71,8 +71,8 @@ def check_roll(device):
     a = make_tensor(base_np, device, True)
     weight = make_tensor(weight_np, device)
 
-    out = eng.roll(a, [1, -1], [0, 1])
-    backward_sum(eng.mul(out, weight))
+    out = _C_engine.roll(a, [1, -1], [0, 1])
+    backward_sum(_C_engine.mul(out, weight))
     expected = np.roll(weight_np, shift=(-1, 1), axis=(0, 1))
     check(f"roll ({device.name})", grad_np(a), expected)
 
@@ -85,7 +85,7 @@ def check_gather(device):
     idx = make_tensor(idx_np, device)
     weight = make_tensor(weight_np, device)
 
-    backward_sum(eng.mul(eng.gather(a, idx, 1), weight))
+    backward_sum(_C_engine.mul(_C_engine.gather(a, idx, 1), weight))
     expected = np.zeros_like(src_np)
     for row in range(idx_np.shape[0]):
         for col in range(idx_np.shape[1]):
@@ -99,7 +99,7 @@ def check_diagonal(device):
     a = make_tensor(src_np, device, True)
     weight = make_tensor(weight_np, device)
 
-    backward_sum(eng.mul(eng.diagonal(a, 1, 1, 2), weight))
+    backward_sum(_C_engine.mul(_C_engine.diagonal(a, 1, 1, 2), weight))
     expected = np.zeros_like(src_np)
     for batch in range(2):
         for i in range(3):
@@ -113,12 +113,12 @@ def check_tri(device):
 
     a = make_tensor(base_np, device, True)
     weight = make_tensor(weight_np, device)
-    backward_sum(eng.mul(eng.tril(a, 0), weight))
+    backward_sum(_C_engine.mul(_C_engine.tril(a, 0), weight))
     check(f"tril ({device.name})", grad_np(a), np.tril(weight_np, 0))
 
     a = make_tensor(base_np, device, True)
     weight = make_tensor(weight_np, device)
-    backward_sum(eng.mul(eng.triu(a, 1), weight))
+    backward_sum(_C_engine.mul(_C_engine.triu(a, 1), weight))
     check(f"triu ({device.name})", grad_np(a), np.triu(weight_np, 1))
 
 
@@ -127,7 +127,7 @@ def check_sort_topk(device):
     weight_np = np.array([[10, 20, 30, 40], [1, 2, 3, 4]], dtype=np.float32)
     a = make_tensor(src_np, device, True)
     weight = make_tensor(weight_np, device)
-    backward_sum(eng.mul(eng.sort(a, 1), weight))
+    backward_sum(_C_engine.mul(_C_engine.sort(a, 1), weight))
     expected = np.zeros_like(src_np)
     order = np.argsort(src_np, axis=1)
     for row in range(src_np.shape[0]):
@@ -138,7 +138,7 @@ def check_sort_topk(device):
     weight_np = np.array([[10, 20], [1, 2]], dtype=np.float32)
     a = make_tensor(src_np, device, True)
     weight = make_tensor(weight_np, device)
-    backward_sum(eng.mul(eng.topk(a, 2, 1), weight))
+    backward_sum(_C_engine.mul(_C_engine.topk(a, 2, 1), weight))
     expected = np.zeros_like(src_np)
     order = np.argsort(src_np, axis=1)[:, ::-1][:, :2]
     for row in range(src_np.shape[0]):
@@ -155,12 +155,12 @@ def check_meshgrid(device):
 
     x = make_tensor(x_np, device, True)
     y = make_tensor(y_np, device, True)
-    gx, gy = eng.meshgrid([x, y], False)
+    gx, gy = _C_engine.meshgrid([x, y], False)
     wx = make_tensor(wx_np, device)
     wy = make_tensor(wy_np, device)
-    loss = eng.add(eng.sum(eng.mul(gx, wx), [], False),
-                   eng.sum(eng.mul(gy, wy), [], False))
-    eng.engine_backward(loss, retain_graph=False)
+    loss = _C_engine.add(_C_engine.sum(_C_engine.mul(gx, wx), [], False),
+                   _C_engine.sum(_C_engine.mul(gy, wy), [], False))
+    _C_engine.engine_backward(loss, retain_graph=False)
     check(f"meshgrid x ij ({device.name})", grad_np(x), wx_np.sum(axis=1))
     check(f"meshgrid y ij ({device.name})", grad_np(y), wy_np.sum(axis=0))
 
@@ -168,12 +168,12 @@ def check_meshgrid(device):
     wy_np = np.array([[7, 8, 9], [10, 11, 12]], dtype=np.float32)
     x = make_tensor(x_np, device, True)
     y = make_tensor(y_np, device, True)
-    gx, gy = eng.meshgrid([x, y], True)
+    gx, gy = _C_engine.meshgrid([x, y], True)
     wx = make_tensor(wx_np, device)
     wy = make_tensor(wy_np, device)
-    loss = eng.add(eng.sum(eng.mul(gx, wx), [], False),
-                   eng.sum(eng.mul(gy, wy), [], False))
-    eng.engine_backward(loss, retain_graph=False)
+    loss = _C_engine.add(_C_engine.sum(_C_engine.mul(gx, wx), [], False),
+                   _C_engine.sum(_C_engine.mul(gy, wy), [], False))
+    _C_engine.engine_backward(loss, retain_graph=False)
     check(f"meshgrid x xy ({device.name})", grad_np(x), wx_np.sum(axis=0))
     check(f"meshgrid y xy ({device.name})", grad_np(y), wy_np.sum(axis=1))
 
@@ -195,8 +195,8 @@ def check_device(device):
 
 
 def main():
-    check_device(eng.Device.CPU)
-    check_device(eng.Device.GPU)
+    check_device(_C_engine.Device.CPU)
+    check_device(_C_engine.Device.GPU)
     print(f"\n--- TOTAL: {PASSED} passed, {FAILED} failed ---")
     return 0 if FAILED == 0 else 1
 


### PR DESCRIPTION
## Summary

Project convention: every Python-side import that crosses into a C extension (``lucid._C.*``) must use an alias with the ``_C_{name}`` prefix so the Python/C boundary is immediately visible in source. Non-conforming aliases like ``_eng``, ``eng``, ``_E``, plain ``engine``, etc. are forbidden.

This PR makes the codebase comply.

## What changed

Renamed in **14 files** — 12 verifier scripts and 3 lucid source files (``lucid/__init__.py``, ``lucid/optim/__init__.py``, ``lucid/optim/lr_scheduler/__init__.py``):

```python
# before
from lucid._C import engine as _eng         # also: as eng / as _E
... = _eng.SGD                              # also: eng.X / _E.X

# after
from lucid._C import engine as _C_engine
... = _C_engine.SGD
```

Mechanical rewrite via `re.sub`; no behavioural changes.

## Verification

Full regression + coverage sweep still 159/159 passing on Apple Silicon (Python 3.14, MLX latest):

| Script | Result |
|--------|--------|
| ``verify_grid_sample_gpu.py`` | 9 / 9 |
| ``verify_layout_unfold_gpu.py`` | 12 / 12 |
| ``verify_utils_grad.py`` | 28 / 28 |
| ``verify_phase4d_grad.py`` | 11 / 11 |
| ``verify_phase4d_cpu.py`` | 21 / 21 |
| ``verify_phase6_9.py`` | 28 / 28 |
| ``verify_full_coverage.py`` | 50 / 50 |
| **Total** | **159 / 159** |

A grep for any remaining stale aliases (`as _eng`, `as eng`, `as _E`, etc.) returns nothing.

## Notes for reviewers
- The rule is also captured in the agent-side memory so subsequent work doesn't re-introduce non-conforming aliases.
- ``lucid_legacy/`` is left untouched on purpose (frozen reference tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)