### PR TITLE
Deep semantics fixes (P0/P1/P2): broadcasting, batched matmul, linalg CPU, einsum/tensordot/cumprod autograd, adaptive_pool, GPU output device tracking

### DIFF
--- a/lucid/_C/ops/bfunc/Matmul.cpp
+++ b/lucid/_C/ops/bfunc/Matmul.cpp
@@ -59,62 +59,175 @@ CpuStorage cpu_matmul(const CpuStorage& a, const CpuStorage& b,
     return out;
 }
 
+// CPU N-D matmul: a [..., M, K] @ b [..., K, N] → out [..., M, N]
+// Leading dims of a/b are broadcast-aligned; the kernel iterates over the
+// flattened batch dim and calls sgemm/dgemm per slice.
+struct NdMatmulInfo {
+    Shape out_shape;
+    Shape a_bcast_shape;
+    Shape b_bcast_shape;
+    int M, K, N;
+    std::size_t batch;
+};
+
+NdMatmulInfo plan_nd_matmul(const Shape& a, const Shape& b) {
+    if (a.size() < 2 || b.size() < 2)
+        throw ShapeMismatch(a, b, "matmul: both operands must be ≥2-D");
+    const std::size_t na = a.size(), nb = b.size();
+    const std::int64_t M = a[na - 2], Ka = a[na - 1];
+    const std::int64_t Kb = b[nb - 2], N = b[nb - 1];
+    if (Ka != Kb)
+        throw ShapeMismatch(a, b, "matmul: inner dim mismatch");
+
+    Shape ba(a.begin(), a.end() - 2);
+    Shape bb(b.begin(), b.end() - 2);
+    Shape out_b;
+    if (ba.empty()) out_b = bb;
+    else if (bb.empty()) out_b = ba;
+    else {
+        // Broadcast leading batch dims.
+        const std::size_t r = std::max(ba.size(), bb.size());
+        out_b.assign(r, 1);
+        for (std::size_t i = 0; i < r; ++i) {
+            const std::size_t ai = (ba.size() >= r - i) ? ba.size() - (r - i) : SIZE_MAX;
+            const std::size_t bi = (bb.size() >= r - i) ? bb.size() - (r - i) : SIZE_MAX;
+            const std::int64_t da = (ai != SIZE_MAX) ? ba[ai] : 1;
+            const std::int64_t db = (bi != SIZE_MAX) ? bb[bi] : 1;
+            if (da == db || da == 1 || db == 1) out_b[i] = da == 1 ? db : da;
+            else throw ShapeMismatch(a, b, "matmul: incompatible batch dims");
+        }
+    }
+    NdMatmulInfo info;
+    info.out_shape = out_b;
+    info.out_shape.push_back(M);
+    info.out_shape.push_back(N);
+    info.a_bcast_shape = out_b;
+    info.a_bcast_shape.push_back(M);
+    info.a_bcast_shape.push_back(Ka);
+    info.b_bcast_shape = out_b;
+    info.b_bcast_shape.push_back(Kb);
+    info.b_bcast_shape.push_back(N);
+    info.M = static_cast<int>(M);
+    info.K = static_cast<int>(Ka);
+    info.N = static_cast<int>(N);
+    std::size_t batch = 1;
+    for (auto d : out_b) batch *= static_cast<std::size_t>(d);
+    info.batch = batch;
+    return info;
+}
+
+CpuStorage cpu_matmul_nd(const CpuStorage& a, const CpuStorage& b,
+                          const NdMatmulInfo& info, bool transA, bool transB,
+                          Dtype dt) {
+    const std::size_t batch = info.batch;
+    const int M = info.M, K = info.K, N = info.N;
+    const std::size_t a_step = static_cast<std::size_t>(M) * K;
+    const std::size_t b_step = static_cast<std::size_t>(K) * N;
+    const std::size_t o_step = static_cast<std::size_t>(M) * N;
+    CpuStorage out;
+    out.dtype  = dt;
+    out.nbytes = batch * o_step * dtype_size(dt);
+    out.ptr    = allocate_aligned_bytes(out.nbytes);
+    if (M == 0 || N == 0 || K == 0) {
+        if (out.nbytes) std::memset(out.ptr.get(), 0, out.nbytes);
+        return out;
+    }
+    auto run = [&](auto type_tag) {
+        using T = decltype(type_tag);
+        const T* ap = reinterpret_cast<const T*>(a.ptr.get());
+        const T* bp = reinterpret_cast<const T*>(b.ptr.get());
+        T* op = reinterpret_cast<T*>(out.ptr.get());
+        const int lda = transA ? M : K;
+        const int ldb = transB ? K : N;
+        for (std::size_t bi = 0; bi < batch; ++bi) {
+            if constexpr (std::is_same_v<T, float>) {
+                backend::cpu::sgemm(transA, transB, M, N, K, 1.0f,
+                                      ap + bi * a_step, lda,
+                                      bp + bi * b_step, ldb, 0.0f,
+                                      op + bi * o_step, N);
+            } else {
+                backend::cpu::dgemm(transA, transB, M, N, K, 1.0,
+                                      ap + bi * a_step, lda,
+                                      bp + bi * b_step, ldb, 0.0,
+                                      op + bi * o_step, N);
+            }
+        }
+    };
+    if (dt == Dtype::F32) run(float{});
+    else if (dt == Dtype::F64) run(double{});
+    else throw NotImplementedError("matmul: dtype not supported (F32/F64)");
+    return out;
+}
+
 }  // namespace
 
 std::vector<Storage> MatmulBackward::apply(Storage grad_out) {
-    // Saved: input_shapes_[0] = [M, K], input_shapes_[1] = [K, N]
-    // grad_out: [M, N], saved_inputs_[0] = A, saved_inputs_[1] = B.
-    const int M = static_cast<int>(input_shapes_[0][0]);
-    const int K = static_cast<int>(input_shapes_[0][1]);
-    const int N = static_cast<int>(input_shapes_[1][1]);
+    // For batched / broadcast matmul: dA = grad @ B^T, dB = A^T @ grad,
+    // each computed at the broadcast shape (info.a_bcast_shape /
+    // .b_bcast_shape) and then reduced back to the original input shapes
+    // via reduce_grad_to_shape (handles broadcast-undo).
+    const auto info = plan_nd_matmul(input_shapes_[0], input_shapes_[1]);
 
     if (device_ == Device::GPU) {
         const auto& gA = std::get<GpuStorage>(saved_inputs_[0]);
         const auto& gB = std::get<GpuStorage>(saved_inputs_[1]);
         const auto& gG = std::get<GpuStorage>(grad_out);
-        if (!gA.arr || !gB.arr || !gG.arr) {
+        if (!gA.arr || !gB.arr || !gG.arr)
             throw LucidError("matmul backward: null GPU array");
-        }
-        // dA = grad @ B^T ; dB = A^T @ grad. MLX has no separate transpose
-        // flag on matmul; use ::mlx::core::transpose explicitly. Empty cases
-        // (M/N/K == 0) fall through naturally — MLX returns empty arrays.
-        if (M == 0 || N == 0 || K == 0) {
-            auto za = ::mlx::core::zeros(gpu::to_mlx_shape(input_shapes_[0]),
-                                         gpu::to_mlx_dtype(dtype_));
-            auto zb = ::mlx::core::zeros(gpu::to_mlx_shape(input_shapes_[1]),
-                                         gpu::to_mlx_dtype(dtype_));
-            return {Storage{gpu::wrap_mlx_array(std::move(za), dtype_)},
-                    Storage{gpu::wrap_mlx_array(std::move(zb), dtype_)}};
-        }
-        auto bT = ::mlx::core::transpose(*gB.arr);
-        auto aT = ::mlx::core::transpose(*gA.arr);
+        // dA = grad @ B^T  (B^T = swapaxes(B, -2, -1))
+        // dB = A^T @ grad
+        auto bT = ::mlx::core::swapaxes(*gB.arr, -2, -1);
+        auto aT = ::mlx::core::swapaxes(*gA.arr, -2, -1);
         auto dA = ::mlx::core::matmul(*gG.arr, bT);
         auto dB = ::mlx::core::matmul(aT, *gG.arr);
-        return {Storage{gpu::wrap_mlx_array(std::move(dA), dtype_)},
-                Storage{gpu::wrap_mlx_array(std::move(dB), dtype_)}};
+        // reduce_grad_to_shape collapses any broadcast batch dims back to
+        // the original input shapes.
+        Storage dA_s{gpu::wrap_mlx_array(std::move(dA), dtype_)};
+        Storage dB_s{gpu::wrap_mlx_array(std::move(dB), dtype_)};
+        dA_s = reduce_grad_to_shape(std::move(dA_s), info.a_bcast_shape,
+                                       input_shapes_[0], dtype_, device_);
+        dB_s = reduce_grad_to_shape(std::move(dB_s), info.b_bcast_shape,
+                                       input_shapes_[1], dtype_, device_);
+        return {std::move(dA_s), std::move(dB_s)};
     }
 
-    const auto& g_cpu = std::get<CpuStorage>(grad_out);
-    const auto& a_cpu = std::get<CpuStorage>(saved_inputs_[0]);
-    const auto& b_cpu = std::get<CpuStorage>(saved_inputs_[1]);
+    // CPU: per-slice GEMM with transA / transB at the broadcast shape.
+    const CpuStorage& aRaw = std::get<CpuStorage>(saved_inputs_[0]);
+    const CpuStorage& bRaw = std::get<CpuStorage>(saved_inputs_[1]);
+    const CpuStorage& gRaw = std::get<CpuStorage>(grad_out);
 
-    // Item #7 — empty case: cblas rejects 0-sized BLAS calls. Allocate
-    // zero-filled grads of the right shape instead.
-    auto empty_grad = [this](int rows, int cols) -> Storage {
-        auto cpu = allocate_2d(rows, cols, this->dtype_);
-        if (cpu.nbytes > 0) std::memset(cpu.ptr.get(), 0, cpu.nbytes);
-        return Storage{std::move(cpu)};
-    };
+    CpuStorage aBuf, bBuf;
+    const CpuStorage* aUse = &aRaw;
+    const CpuStorage* bUse = &bRaw;
+    if (input_shapes_[0] != info.a_bcast_shape) {
+        aBuf = detail::broadcast_cpu(aRaw, input_shapes_[0], info.a_bcast_shape, dtype_);
+        aUse = &aBuf;
+    }
+    if (input_shapes_[1] != info.b_bcast_shape) {
+        bBuf = detail::broadcast_cpu(bRaw, input_shapes_[1], info.b_bcast_shape, dtype_);
+        bUse = &bBuf;
+    }
 
-    Storage dA = (M == 0 || K == 0 || N == 0)
-        ? empty_grad(M, K)
-        : Storage{cpu_matmul(g_cpu, b_cpu, M, K, N,
-                             /*transA=*/false, /*transB=*/true, dtype_)};
-    Storage dB = (K == 0 || N == 0 || M == 0)
-        ? empty_grad(K, N)
-        : Storage{cpu_matmul(a_cpu, g_cpu, K, N, M,
-                             /*transA=*/true, /*transB=*/false, dtype_)};
-    return {std::move(dA), std::move(dB)};
+    // Build the "a-shaped" backward result: grad @ B^T (per slice).
+    NdMatmulInfo dA_info = info;
+    dA_info.M = info.M; dA_info.N = info.K;
+    NdMatmulInfo dB_info = info;
+    dB_info.M = info.K; dB_info.N = info.N;
+
+    CpuStorage dA_cpu = cpu_matmul_nd(gRaw, *bUse, NdMatmulInfo{
+        info.a_bcast_shape, {}, {}, info.M, info.N, info.K, info.batch},
+        /*transA=*/false, /*transB=*/true, dtype_);
+    CpuStorage dB_cpu = cpu_matmul_nd(*aUse, gRaw, NdMatmulInfo{
+        info.b_bcast_shape, {}, {}, info.K, info.M, info.N, info.batch},
+        /*transA=*/true, /*transB=*/false, dtype_);
+
+    Storage dA_s{std::move(dA_cpu)};
+    Storage dB_s{std::move(dB_cpu)};
+    dA_s = reduce_grad_to_shape(std::move(dA_s), info.a_bcast_shape,
+                                   input_shapes_[0], dtype_, device_);
+    dB_s = reduce_grad_to_shape(std::move(dB_s), info.b_bcast_shape,
+                                   input_shapes_[1], dtype_, device_);
+    return {std::move(dA_s), std::move(dB_s)};
 }
 
 TensorImplPtr MatmulBackward::forward(const TensorImplPtr& a, const TensorImplPtr& b) {
@@ -125,12 +238,9 @@ TensorImplPtr MatmulBackward::forward(const TensorImplPtr& a, const TensorImplPt
     if (a->device_ != b->device_)
         throw DeviceMismatch(std::string(device_name(a->device_)),
                              std::string(device_name(b->device_)), "matmul");
-    if (a->shape_.size() != 2 || b->shape_.size() != 2) {
+    if (a->shape_.size() < 2 || b->shape_.size() < 2) {
         throw ShapeMismatch(a->shape_, b->shape_,
-                            "matmul (Phase 3.1: 2-D only)");
-    }
-    if (a->shape_[1] != b->shape_[0]) {
-        throw ShapeMismatch(a->shape_, b->shape_, "matmul (inner dim mismatch)");
+                            "matmul: both operands must be ≥2-D");
     }
     // Item #8 — non-contiguous input guard. CPU only (GPU stride is internal).
     if (a->device_ == Device::CPU &&
@@ -140,49 +250,43 @@ TensorImplPtr MatmulBackward::forward(const TensorImplPtr& a, const TensorImplPt
             "(call .contiguous() first)");
     }
 
-    const int M = static_cast<int>(a->shape_[0]);
-    const int K = static_cast<int>(a->shape_[1]);
-    const int N = static_cast<int>(b->shape_[1]);
+    const auto info = plan_nd_matmul(a->shape_, b->shape_);
+    const int M = info.M, N = info.N, K = info.K;
 
     OpScope scope{MatmulBackward::schema_v1.name, a->device_, a->dtype_,
-                  Shape{a->shape_[0], b->shape_[1]}};
-    scope.set_flops(static_cast<std::int64_t>(2) * M * N * K);  // 2*M*N*K standard
+                  info.out_shape};
+    scope.set_flops(static_cast<std::int64_t>(2) * info.batch * M * N * K);
 
     Storage out_storage;
     if (a->device_ == Device::GPU) {
-        if (M == 0 || N == 0 || K == 0) {
-            auto z = ::mlx::core::zeros(
-                gpu::to_mlx_shape(Shape{a->shape_[0], b->shape_[1]}),
-                gpu::to_mlx_dtype(a->dtype_));
-            out_storage = Storage{gpu::wrap_mlx_array(std::move(z), a->dtype_)};
-        } else {
-            const auto& gA = std::get<GpuStorage>(a->storage_);
-            const auto& gB = std::get<GpuStorage>(b->storage_);
-            auto out = ::mlx::core::matmul(*gA.arr, *gB.arr);
-            out_storage =
-                Storage{gpu::wrap_mlx_array(std::move(out), a->dtype_)};
-        }
+        const auto& gA = std::get<GpuStorage>(a->storage_);
+        const auto& gB = std::get<GpuStorage>(b->storage_);
+        // MLX matmul handles batched N-D inputs natively (with broadcasting
+        // over leading axes). No manual reshape needed.
+        auto out = ::mlx::core::matmul(*gA.arr, *gB.arr);
+        out_storage = Storage{gpu::wrap_mlx_array(std::move(out), a->dtype_)};
     } else {
-        // Item #7 — empty inner dim: cblas_sgemm rejects K=0 with
-        // "lda >= max(K,1)". Empty matmul over an empty inner dim produces an
-        // all-zeros output (empty sum convention).
-        CpuStorage out_storage_cpu;
-        if (M == 0 || N == 0 || K == 0) {
-            out_storage_cpu = allocate_2d(M, N, a->dtype_);
-            if (out_storage_cpu.nbytes > 0) {
-                std::memset(out_storage_cpu.ptr.get(), 0, out_storage_cpu.nbytes);
-            }
-        } else {
-            out_storage_cpu = cpu_matmul(std::get<CpuStorage>(a->storage_),
-                                         std::get<CpuStorage>(b->storage_),
-                                         M, N, K, /*transA=*/false,
-                                         /*transB=*/false, a->dtype_);
+        // CPU: materialize broadcast for batch dims, then per-slice GEMM.
+        const CpuStorage& aRaw = std::get<CpuStorage>(a->storage_);
+        const CpuStorage& bRaw = std::get<CpuStorage>(b->storage_);
+        CpuStorage aBuf, bBuf;
+        const CpuStorage* aUse = &aRaw;
+        const CpuStorage* bUse = &bRaw;
+        if (a->shape_ != info.a_bcast_shape) {
+            aBuf = detail::broadcast_cpu(aRaw, a->shape_, info.a_bcast_shape, a->dtype_);
+            aUse = &aBuf;
         }
-        out_storage = Storage{std::move(out_storage_cpu)};
+        if (b->shape_ != info.b_bcast_shape) {
+            bBuf = detail::broadcast_cpu(bRaw, b->shape_, info.b_bcast_shape, a->dtype_);
+            bUse = &bBuf;
+        }
+        out_storage = Storage{cpu_matmul_nd(*aUse, *bUse, info,
+                                              /*transA=*/false,
+                                              /*transB=*/false, a->dtype_)};
     }
 
     auto out = std::make_shared<TensorImpl>(std::move(out_storage),
-                                            Shape{a->shape_[0], b->shape_[1]},
+                                            info.out_shape,
                                             a->dtype_, a->device_,
                                             /*requires_grad=*/false);
 

--- a/lucid/_C/ops/bfunc/_BinaryOp.h
+++ b/lucid/_C/ops/bfunc/_BinaryOp.h
@@ -26,9 +26,14 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
+
+#include <mlx/ops.h>
 
 #include "../../api.h"
+#include "../../backend/gpu/MlxBridge.h"
 #include "../../core/AmpPolicy.h"
+#include "../../core/Allocator.h"
 #include "../../core/Exceptions.h"
 #include "../../core/GradMode.h"
 #include "../../core/OpSchema.h"
@@ -48,6 +53,80 @@ template <class T>
 concept HasGpuKernel = requires(GpuStorage a, GpuStorage b, Shape s, Dtype d) {
     { T::gpu_kernel(a, b, s, d) } -> std::same_as<GpuStorage>;
 };
+
+// NumPy-style broadcast shape resolution.  Returns the broadcast result
+// shape; throws ShapeMismatch when shapes are incompatible.  Right-aligned:
+// missing leading axes are treated as size 1, and any axis pair (1, n) or
+// (n, 1) is allowed.
+inline Shape broadcast_shapes(const Shape& a, const Shape& b) {
+    const std::size_t ra = a.size();
+    const std::size_t rb = b.size();
+    const std::size_t r = ra > rb ? ra : rb;
+    Shape out(r, 1);
+    for (std::size_t i = 0; i < r; ++i) {
+        const std::size_t ai = (ra >= r - i) ? ra - (r - i) : SIZE_MAX;
+        const std::size_t bi = (rb >= r - i) ? rb - (r - i) : SIZE_MAX;
+        const std::int64_t da = (ai != SIZE_MAX) ? a[ai] : 1;
+        const std::int64_t db = (bi != SIZE_MAX) ? b[bi] : 1;
+        if (da == db || da == 1 || db == 1) {
+            out[i] = da == 1 ? db : da;
+        } else {
+            throw ShapeMismatch(a, b, "broadcast: incompatible shapes");
+        }
+    }
+    return out;
+}
+
+// CPU broadcast-materialize: read input contiguously per output element.
+inline CpuStorage broadcast_cpu(const CpuStorage& src, const Shape& src_shape,
+                                  const Shape& out_shape, Dtype dt) {
+    const std::size_t ndim_out = out_shape.size();
+    const std::size_t ndim_in  = src_shape.size();
+    Shape padded(ndim_out, 1);
+    for (std::size_t i = 0; i < ndim_in; ++i) {
+        padded[ndim_out - ndim_in + i] = src_shape[i];
+    }
+    // Strides over the *padded* input shape, with 0 where the axis was 1.
+    std::vector<std::size_t> in_str(ndim_out, 0);
+    std::size_t s = 1;
+    for (std::ptrdiff_t d = (std::ptrdiff_t)ndim_out - 1; d >= 0; --d) {
+        in_str[d] = (padded[d] == 1) ? 0 : s;
+        s *= static_cast<std::size_t>(padded[d]);
+    }
+    const std::size_t out_numel = shape_numel(out_shape);
+    CpuStorage out;
+    out.dtype  = dt;
+    out.nbytes = out_numel * dtype_size(dt);
+    out.ptr    = allocate_aligned_bytes(out.nbytes);
+
+    auto run = [&](auto type_tag) {
+        using T = decltype(type_tag);
+        const T* sp = reinterpret_cast<const T*>(src.ptr.get());
+        T* dp = reinterpret_cast<T*>(out.ptr.get());
+        std::vector<std::size_t> coord(ndim_out, 0);
+        for (std::size_t f = 0; f < out_numel; ++f) {
+            std::size_t in_flat = 0;
+            for (std::size_t d = 0; d < ndim_out; ++d)
+                in_flat += coord[d] * in_str[d];
+            dp[f] = sp[in_flat];
+            for (std::ptrdiff_t d = (std::ptrdiff_t)ndim_out - 1; d >= 0; --d) {
+                if (++coord[d] < static_cast<std::size_t>(out_shape[d])) break;
+                coord[d] = 0;
+            }
+        }
+    };
+    switch (dt) {
+        case Dtype::F32: run(float{}); break;
+        case Dtype::F64: run(double{}); break;
+        case Dtype::I32: run(std::int32_t{}); break;
+        case Dtype::I64: run(std::int64_t{}); break;
+        case Dtype::I16: run(std::int16_t{}); break;
+        case Dtype::I8:  case Dtype::Bool: run(std::uint8_t{}); break;
+        default:
+            throw NotImplementedError("broadcast: dtype not supported");
+    }
+    return out;
+}
 
 /// Walk a tensor; if it's a leaf needing grad, attach (or reuse) an
 /// AccumulateGrad as its grad_fn. Else return its existing grad_fn.
@@ -98,14 +177,6 @@ std::shared_ptr<TensorImpl> BinaryOp<Derived>::forward(
                              std::string(device_name(b->device_)),
                              std::string(Derived::schema_v1.name));
     }
-    if (a->shape_ != b->shape_) {
-        // Phase 3.0: equal shapes only. Broadcast forward arrives in Phase 3.1
-        // (will be a separate op-level concern; backward already supports it
-        // via reduce_grad_to_shape).
-        throw ShapeMismatch(a->shape_, b->shape_,
-                            std::string(Derived::schema_v1.name) +
-                                " (broadcast forward not yet implemented)");
-    }
     // Item #8 — non-contiguous input guard. Phase 3.4 view ops produce
     // non-contiguous tensors; user must call .contiguous() before compute.
     // CPU only — GPU contiguity is internal to MLX, not exposed via stride_.
@@ -116,29 +187,62 @@ std::shared_ptr<TensorImpl> BinaryOp<Derived>::forward(
             ": non-contiguous input not supported (call .contiguous() first)");
     }
 
-    OpScope scope{Derived::schema_v1.name, a->device_, a->dtype_, a->shape_};
+    // Resolve broadcast output shape (NumPy semantics). Backward already
+    // accumulates back to each operand's original shape via
+    // reduce_grad_to_shape, so we only have to materialize the broadcast
+    // forward inputs here.
+    Shape out_shape = (a->shape_ == b->shape_)
+                        ? a->shape_
+                        : detail::broadcast_shapes(a->shape_, b->shape_);
+
+    OpScope scope{Derived::schema_v1.name, a->device_, a->dtype_, out_shape};
 
     Storage out_storage;
     if (a->device_ == Device::GPU) {
         if constexpr (detail::HasGpuKernel<Derived>) {
-            out_storage = Storage{Derived::gpu_kernel(
-                std::get<GpuStorage>(a->storage_),
-                std::get<GpuStorage>(b->storage_), a->shape_, a->dtype_)};
+            // Materialize broadcast on GPU via mlx::broadcast_to (lazy view
+            // → contiguous() to give the kernel a real buffer).
+            const auto& ga = std::get<GpuStorage>(a->storage_);
+            const auto& gb = std::get<GpuStorage>(b->storage_);
+            ::mlx::core::array a_arr = (a->shape_ == out_shape)
+                ? *ga.arr
+                : ::mlx::core::contiguous(::mlx::core::broadcast_to(
+                    *ga.arr, gpu::to_mlx_shape(out_shape)));
+            ::mlx::core::array b_arr = (b->shape_ == out_shape)
+                ? *gb.arr
+                : ::mlx::core::contiguous(::mlx::core::broadcast_to(
+                    *gb.arr, gpu::to_mlx_shape(out_shape)));
+            GpuStorage a_g, b_g;
+            a_g.arr = std::make_shared<::mlx::core::array>(std::move(a_arr));
+            b_g.arr = std::make_shared<::mlx::core::array>(std::move(b_arr));
+            out_storage = Storage{Derived::gpu_kernel(a_g, b_g, out_shape,
+                                                       a->dtype_)};
         } else {
             throw NotImplementedError(
                 std::string(Derived::schema_v1.name) +
                 ": GPU kernel not yet implemented (Phase 3.7.x in progress)");
         }
     } else {
-        // CPU forward — Derived returns the output Storage. Allocation is the
-        // kernel's responsibility (lets it choose layout for fused ops).
-        out_storage =
-            Storage{Derived::cpu_kernel(std::get<CpuStorage>(a->storage_),
-                                        std::get<CpuStorage>(b->storage_),
-                                        a->shape_, a->dtype_)};
+        // Materialize broadcast on CPU when shapes differ.
+        const CpuStorage& a_raw = std::get<CpuStorage>(a->storage_);
+        const CpuStorage& b_raw = std::get<CpuStorage>(b->storage_);
+        CpuStorage a_buf;
+        CpuStorage b_buf;
+        const CpuStorage* a_use = &a_raw;
+        const CpuStorage* b_use = &b_raw;
+        if (a->shape_ != out_shape) {
+            a_buf = detail::broadcast_cpu(a_raw, a->shape_, out_shape, a->dtype_);
+            a_use = &a_buf;
+        }
+        if (b->shape_ != out_shape) {
+            b_buf = detail::broadcast_cpu(b_raw, b->shape_, out_shape, a->dtype_);
+            b_use = &b_buf;
+        }
+        out_storage = Storage{Derived::cpu_kernel(*a_use, *b_use,
+                                                    out_shape, a->dtype_)};
     }
 
-    auto out = std::make_shared<TensorImpl>(std::move(out_storage), a->shape_,
+    auto out = std::make_shared<TensorImpl>(std::move(out_storage), out_shape,
                                             a->dtype_, a->device_,
                                             /*requires_grad=*/false);
 

--- a/lucid/_C/ops/linalg/Cholesky.cpp
+++ b/lucid/_C/ops/linalg/Cholesky.cpp
@@ -15,11 +15,10 @@ namespace lucid {
 TensorImplPtr cholesky_op(const TensorImplPtr& a, bool upper) {
     using namespace linalg_detail;
     if (!a) throw LucidError("cholesky: null input");
-    require_gpu(a, "cholesky");
     OpScope scope{"cholesky", a->device_, a->dtype_, a->shape_};
-    const auto& ga = std::get<GpuStorage>(a->storage_);
-    auto out = ::mlx::core::linalg::cholesky(*ga.arr, upper, kMlxCpu);
-    return fresh(Storage{gpu::wrap_mlx_array(std::move(out), a->dtype_)},
+    auto in = as_mlx_array(a);
+    auto out = ::mlx::core::linalg::cholesky(in, upper, kMlxCpu);
+    return fresh(wrap_result(std::move(out), a->dtype_, a->device_, a->shape_),
                  a->shape_, a->dtype_, a->device_);
 }
 

--- a/lucid/_C/ops/linalg/Det.cpp
+++ b/lucid/_C/ops/linalg/Det.cpp
@@ -16,11 +16,10 @@ namespace lucid {
 TensorImplPtr det_op(const TensorImplPtr& a) {
     using namespace linalg_detail;
     if (!a) throw LucidError("det: null input");
-    require_gpu(a, "det");
     OpScope scope{"det", a->device_, a->dtype_, a->shape_};
-    const auto& ga = std::get<GpuStorage>(a->storage_);
+    auto in = as_mlx_array(a);
     // MLX has no direct det. Compute via LU: det(A) = prod(diag(U)).
-    auto factors = ::mlx::core::linalg::lu(*ga.arr, kMlxCpu);
+    auto factors = ::mlx::core::linalg::lu(in, kMlxCpu);
     if (factors.size() < 3)
         throw LucidError("det: lu returned fewer than 3 factors");
     const auto& U = factors[2];
@@ -29,7 +28,7 @@ TensorImplPtr det_op(const TensorImplPtr& a) {
     auto diag = ::mlx::core::diagonal(U, 0, -2, -1);
     auto detU = ::mlx::core::prod(diag, /*keepdims=*/false);
     Shape out_shape = mlx_shape_to_lucid(detU.shape());
-    return fresh(Storage{gpu::wrap_mlx_array(std::move(detU), a->dtype_)},
+    return fresh(wrap_result(std::move(detU), a->dtype_, a->device_, out_shape),
                  std::move(out_shape), a->dtype_, a->device_);
 }
 

--- a/lucid/_C/ops/linalg/Eig.cpp
+++ b/lucid/_C/ops/linalg/Eig.cpp
@@ -15,16 +15,15 @@ namespace lucid {
 std::pair<TensorImplPtr, TensorImplPtr> eig_op(const TensorImplPtr& a) {
     using namespace linalg_detail;
     if (!a) throw LucidError("eig: null input");
-    require_gpu(a, "eig");
     OpScope scope{"eig", a->device_, a->dtype_, a->shape_};
-    const auto& ga = std::get<GpuStorage>(a->storage_);
-    auto [w, v] = ::mlx::core::linalg::eig(*ga.arr, kMlxCpu);
+    auto in = as_mlx_array(a);
+    auto [w, v] = ::mlx::core::linalg::eig(in, kMlxCpu);
     Shape wsh = mlx_shape_to_lucid(w.shape());
     Shape vsh = mlx_shape_to_lucid(v.shape());
     return {
-        fresh(Storage{gpu::wrap_mlx_array(std::move(w), a->dtype_)},
+        fresh(wrap_result(std::move(w), a->dtype_, a->device_, wsh),
               std::move(wsh), a->dtype_, a->device_),
-        fresh(Storage{gpu::wrap_mlx_array(std::move(v), a->dtype_)},
+        fresh(wrap_result(std::move(v), a->dtype_, a->device_, vsh),
               std::move(vsh), a->dtype_, a->device_),
     };
 }

--- a/lucid/_C/ops/linalg/Inv.cpp
+++ b/lucid/_C/ops/linalg/Inv.cpp
@@ -15,11 +15,10 @@ namespace lucid {
 TensorImplPtr inv_op(const TensorImplPtr& a) {
     using namespace linalg_detail;
     if (!a) throw LucidError("inv: null input");
-    require_gpu(a, "inv");
     OpScope scope{"inv", a->device_, a->dtype_, a->shape_};
-    const auto& ga = std::get<GpuStorage>(a->storage_);
-    auto out = ::mlx::core::linalg::inv(*ga.arr, kMlxCpu);
-    return fresh(Storage{gpu::wrap_mlx_array(std::move(out), a->dtype_)},
+    auto in = as_mlx_array(a);
+    auto out = ::mlx::core::linalg::inv(in, kMlxCpu);
+    return fresh(wrap_result(std::move(out), a->dtype_, a->device_, a->shape_),
                  a->shape_, a->dtype_, a->device_);
 }
 

--- a/lucid/_C/ops/linalg/MatrixPower.cpp
+++ b/lucid/_C/ops/linalg/MatrixPower.cpp
@@ -17,28 +17,27 @@ namespace lucid {
 TensorImplPtr matrix_power_op(const TensorImplPtr& a, int n) {
     using namespace linalg_detail;
     if (!a) throw LucidError("matrix_power: null input");
-    require_gpu(a, "matrix_power");
     if (a->shape_.size() < 2 ||
         a->shape_[a->shape_.size() - 1] != a->shape_[a->shape_.size() - 2])
         throw LucidError("matrix_power: last two dims must be square");
     OpScope scope{"matrix_power", a->device_, a->dtype_, a->shape_};
-    const auto& ga = std::get<GpuStorage>(a->storage_);
+    auto in = as_mlx_array(a);
     if (n == 0) {
         auto eye = ::mlx::core::eye(static_cast<int>(a->shape_.back()),
                                      static_cast<int>(a->shape_.back()), 0,
                                      gpu::to_mlx_dtype(a->dtype_));
-        return fresh(Storage{gpu::wrap_mlx_array(std::move(eye), a->dtype_)},
-                     Shape{a->shape_.back(), a->shape_.back()},
-                     a->dtype_, a->device_);
+        Shape eye_shape{a->shape_.back(), a->shape_.back()};
+        return fresh(wrap_result(std::move(eye), a->dtype_, a->device_, eye_shape),
+                     std::move(eye_shape), a->dtype_, a->device_);
     }
     int reps = std::abs(n);
-    auto base = (n < 0) ? ::mlx::core::linalg::inv(*ga.arr, kMlxCpu) : *ga.arr;
+    auto base = (n < 0) ? ::mlx::core::linalg::inv(in, kMlxCpu) : in;
     ::mlx::core::array result = base;
     for (int i = 1; i < reps; ++i) {
         result = ::mlx::core::matmul(result, base);
     }
     Shape sh = mlx_shape_to_lucid(result.shape());
-    return fresh(Storage{gpu::wrap_mlx_array(std::move(result), a->dtype_)},
+    return fresh(wrap_result(std::move(result), a->dtype_, a->device_, sh),
                  std::move(sh), a->dtype_, a->device_);
 }
 

--- a/lucid/_C/ops/linalg/Norm.cpp
+++ b/lucid/_C/ops/linalg/Norm.cpp
@@ -17,15 +17,14 @@ TensorImplPtr norm_op(const TensorImplPtr& a, double ord,
                       std::vector<int> axis, bool keepdims) {
     using namespace linalg_detail;
     if (!a) throw LucidError("norm: null input");
-    require_gpu(a, "norm");
     OpScope scope{"norm", a->device_, a->dtype_, a->shape_};
-    const auto& ga = std::get<GpuStorage>(a->storage_);
+    auto in = as_mlx_array(a);
     std::optional<std::vector<int>> axis_opt;
     if (!axis.empty()) axis_opt = std::move(axis);
-    auto out = ::mlx::core::linalg::norm(*ga.arr, ord, axis_opt, keepdims,
+    auto out = ::mlx::core::linalg::norm(in, ord, axis_opt, keepdims,
                                           kMlxCpu);
     Shape sh = mlx_shape_to_lucid(out.shape());
-    return fresh(Storage{gpu::wrap_mlx_array(std::move(out), a->dtype_)},
+    return fresh(wrap_result(std::move(out), a->dtype_, a->device_, sh),
                  std::move(sh), a->dtype_, a->device_);
 }
 

--- a/lucid/_C/ops/linalg/Pinv.cpp
+++ b/lucid/_C/ops/linalg/Pinv.cpp
@@ -15,12 +15,11 @@ namespace lucid {
 TensorImplPtr pinv_op(const TensorImplPtr& a) {
     using namespace linalg_detail;
     if (!a) throw LucidError("pinv: null input");
-    require_gpu(a, "pinv");
     OpScope scope{"pinv", a->device_, a->dtype_, a->shape_};
-    const auto& ga = std::get<GpuStorage>(a->storage_);
-    auto out = ::mlx::core::linalg::pinv(*ga.arr, kMlxCpu);
+    auto in = as_mlx_array(a);
+    auto out = ::mlx::core::linalg::pinv(in, kMlxCpu);
     Shape sh = mlx_shape_to_lucid(out.shape());
-    return fresh(Storage{gpu::wrap_mlx_array(std::move(out), a->dtype_)},
+    return fresh(wrap_result(std::move(out), a->dtype_, a->device_, sh),
                  std::move(sh), a->dtype_, a->device_);
 }
 

--- a/lucid/_C/ops/linalg/QR.cpp
+++ b/lucid/_C/ops/linalg/QR.cpp
@@ -15,16 +15,15 @@ namespace lucid {
 std::pair<TensorImplPtr, TensorImplPtr> qr_op(const TensorImplPtr& a) {
     using namespace linalg_detail;
     if (!a) throw LucidError("qr: null input");
-    require_gpu(a, "qr");
     OpScope scope{"qr", a->device_, a->dtype_, a->shape_};
-    const auto& ga = std::get<GpuStorage>(a->storage_);
-    auto [Q, R] = ::mlx::core::linalg::qr(*ga.arr, kMlxCpu);
+    auto in = as_mlx_array(a);
+    auto [Q, R] = ::mlx::core::linalg::qr(in, kMlxCpu);
     Shape qsh = mlx_shape_to_lucid(Q.shape());
     Shape rsh = mlx_shape_to_lucid(R.shape());
     return {
-        fresh(Storage{gpu::wrap_mlx_array(std::move(Q), a->dtype_)},
+        fresh(wrap_result(std::move(Q), a->dtype_, a->device_, qsh),
               std::move(qsh), a->dtype_, a->device_),
-        fresh(Storage{gpu::wrap_mlx_array(std::move(R), a->dtype_)},
+        fresh(wrap_result(std::move(R), a->dtype_, a->device_, rsh),
               std::move(rsh), a->dtype_, a->device_),
     };
 }

--- a/lucid/_C/ops/linalg/SVD.cpp
+++ b/lucid/_C/ops/linalg/SVD.cpp
@@ -15,15 +15,14 @@ namespace lucid {
 std::vector<TensorImplPtr> svd_op(const TensorImplPtr& a, bool compute_uv) {
     using namespace linalg_detail;
     if (!a) throw LucidError("svd: null input");
-    require_gpu(a, "svd");
     OpScope scope{"svd", a->device_, a->dtype_, a->shape_};
-    const auto& ga = std::get<GpuStorage>(a->storage_);
-    auto pieces = ::mlx::core::linalg::svd(*ga.arr, compute_uv, kMlxCpu);
+    auto in = as_mlx_array(a);
+    auto pieces = ::mlx::core::linalg::svd(in, compute_uv, kMlxCpu);
     std::vector<TensorImplPtr> out;
     out.reserve(pieces.size());
     for (auto& p : pieces) {
         Shape sh = mlx_shape_to_lucid(p.shape());
-        out.push_back(fresh(Storage{gpu::wrap_mlx_array(std::move(p), a->dtype_)},
+        out.push_back(fresh(wrap_result(std::move(p), a->dtype_, a->device_, sh),
                             std::move(sh), a->dtype_, a->device_));
     }
     return out;

--- a/lucid/_C/ops/linalg/Solve.cpp
+++ b/lucid/_C/ops/linalg/Solve.cpp
@@ -15,14 +15,15 @@ namespace lucid {
 TensorImplPtr solve_op(const TensorImplPtr& a, const TensorImplPtr& b) {
     using namespace linalg_detail;
     if (!a || !b) throw LucidError("solve: null input");
-    if (a->device_ != b->device_ || a->device_ != Device::GPU)
-        throw NotImplementedError("solve: requires both inputs on device=\"gpu\"");
+    if (a->device_ != b->device_)
+        throw DeviceMismatch(std::string(device_name(a->device_)),
+                              std::string(device_name(b->device_)), "solve");
     OpScope scope{"solve", a->device_, a->dtype_, a->shape_};
-    const auto& ga = std::get<GpuStorage>(a->storage_);
-    const auto& gb = std::get<GpuStorage>(b->storage_);
-    auto out = ::mlx::core::linalg::solve(*ga.arr, *gb.arr, kMlxCpu);
+    auto in_a = as_mlx_array(a);
+    auto in_b = as_mlx_array(b);
+    auto out = ::mlx::core::linalg::solve(in_a, in_b, kMlxCpu);
     Shape sh = mlx_shape_to_lucid(out.shape());
-    return fresh(Storage{gpu::wrap_mlx_array(std::move(out), a->dtype_)},
+    return fresh(wrap_result(std::move(out), a->dtype_, a->device_, sh),
                  std::move(sh), a->dtype_, a->device_);
 }
 

--- a/lucid/_C/ops/linalg/_Detail.h
+++ b/lucid/_C/ops/linalg/_Detail.h
@@ -2,12 +2,16 @@
 
 // =====================================================================
 // linalg internal helpers — shared by Inv/Det/Solve/Cholesky/Norm/QR/SVD/
-// MatrixPower/Pinv/Eig. All linalg ops route through MLX's CPU stream.
+// MatrixPower/Pinv/Eig. All linalg ops route through MLX's CPU stream;
+// for inputs that arrive on CPU, this header provides up/down helpers
+// that wrap the MLX-CPU-stream call transparently.
 // =====================================================================
 
 #include <mlx/array.h>
 #include <mlx/device.h>
+#include <mlx/ops.h>
 
+#include "../../backend/gpu/MlxBridge.h"
 #include "../../core/Exceptions.h"
 #include "../../core/Shape.h"
 #include "../../core/Storage.h"
@@ -28,14 +32,34 @@ inline Shape mlx_shape_to_lucid(const ::mlx::core::Shape& s) {
     return out;
 }
 
-inline void require_gpu(const TensorImplPtr& t, const char* op) {
-    if (t->device_ != Device::GPU)
-        throw NotImplementedError(
-            std::string(op) +
-            ": CPU path not implemented; move tensor to device=\"gpu\"");
-}
-
 // MLX linalg ops are evaluated on the CPU stream.
 inline const ::mlx::core::Device kMlxCpu{::mlx::core::Device::cpu};
+
+// Upload an input tensor to an MLX array regardless of source device.
+// CPU tensors are uploaded once via the bridge; GPU tensors return their
+// existing MLX array directly.  All linalg ops then call MLX with the
+// `kMlxCpu` stream so the actual compute happens on CPU.
+inline ::mlx::core::array as_mlx_array(const TensorImplPtr& t) {
+    if (t->device_ == Device::GPU) {
+        const auto& g = std::get<GpuStorage>(t->storage_);
+        return *g.arr;
+    }
+    auto g = gpu::upload_cpu_to_gpu(std::get<CpuStorage>(t->storage_), t->shape_);
+    return *g.arr;
+}
+
+// Wrap a result MLX array back into the appropriate Storage for `device`.
+// For CPU device we download; for GPU we wrap.
+inline Storage wrap_result(::mlx::core::array&& out, Dtype dtype, Device device,
+                             const Shape& out_shape) {
+    if (device == Device::CPU) {
+        // Force MLX to materialize the array on its (CPU) stream before we
+        // reach into its buffer for the host download.
+        out.eval();
+        GpuStorage tmp = gpu::wrap_mlx_array(std::move(out), dtype);
+        return Storage{gpu::download_gpu_to_cpu(tmp, out_shape)};
+    }
+    return Storage{gpu::wrap_mlx_array(std::move(out), dtype)};
+}
 
 }  // namespace lucid::linalg_detail

--- a/lucid/_C/ops/ufunc/Scan.cpp
+++ b/lucid/_C/ops/ufunc/Scan.cpp
@@ -118,6 +118,92 @@ public:
     }
 };
 
+// cumprod backward.
+//   y_k = x_0 * x_1 * ... * x_k
+//   dx_j = sum_{k >= j} (g_k * y_k) / x_j
+//        = reverse_cumsum(g * y)_j / x_j
+// We materialize this via:
+//   1. forward y = cumprod(x, axis)            (saved at forward time)
+//   2. p = g * y
+//   3. q = reverse_cumsum(p, axis)
+//   4. dx = q / x   (NaN at zeros — same convention as PyTorch)
+class CumprodBackward : public Node {
+public:
+    Shape input_shape_;
+    Dtype dtype_;
+    Device device_;
+    int axis_;
+    Storage saved_x_;
+    Storage saved_y_;
+
+    std::vector<Storage> apply(Storage grad_out) override {
+        if (device_ == Device::GPU) {
+            const auto& gx = std::get<GpuStorage>(saved_x_);
+            const auto& gy = std::get<GpuStorage>(saved_y_);
+            const auto& gg = std::get<GpuStorage>(grad_out);
+            auto p = ::mlx::core::multiply(*gg.arr, *gy.arr);
+            // reverse along axis, cumsum, reverse back
+            std::vector<std::int32_t> idx(input_shape_[axis_]);
+            for (std::int64_t i = 0; i < input_shape_[axis_]; ++i)
+                idx[i] = static_cast<std::int32_t>(input_shape_[axis_] - 1 - i);
+            ::mlx::core::Shape idx_shape(input_shape_.size(), 1);
+            idx_shape[axis_] = input_shape_[axis_];
+            ::mlx::core::array idx_arr(idx.data(), idx_shape, ::mlx::core::int32);
+            idx_arr = ::mlx::core::broadcast_to(idx_arr, gpu::to_mlx_shape(input_shape_));
+            auto p_rev = ::mlx::core::take_along_axis(p, idx_arr, axis_);
+            auto cs = ::mlx::core::cumsum(p_rev, axis_);
+            auto q = ::mlx::core::take_along_axis(cs, idx_arr, axis_);
+            auto dx = ::mlx::core::divide(q, *gx.arr);
+            return {Storage{gpu::wrap_mlx_array(std::move(dx), dtype_)}};
+        }
+        // CPU path: same recipe via the existing reverse/cumsum helpers.
+        const auto& cx = std::get<CpuStorage>(saved_x_);
+        const auto& cy = std::get<CpuStorage>(saved_y_);
+        const auto& cg = std::get<CpuStorage>(grad_out);
+
+        // p = g * y (allocate fresh)
+        CpuStorage p;
+        p.dtype  = dtype_;
+        p.nbytes = cg.nbytes;
+        p.ptr    = allocate_aligned_bytes(p.nbytes);
+        const std::size_t total = shape_numel(input_shape_);
+        auto mul_kernel = [&](auto type_tag) {
+            using T = decltype(type_tag);
+            const T* gp = reinterpret_cast<const T*>(cg.ptr.get());
+            const T* yp = reinterpret_cast<const T*>(cy.ptr.get());
+            T* op = reinterpret_cast<T*>(p.ptr.get());
+            for (std::size_t i = 0; i < total; ++i) op[i] = gp[i] * yp[i];
+        };
+        if (dtype_ == Dtype::F32) mul_kernel(float{});
+        else if (dtype_ == Dtype::F64) mul_kernel(double{});
+        else throw NotImplementedError("cumprod backward: dtype not supported");
+
+        Storage p_s{std::move(p)};
+        Storage rev = reverse_along_axis_storage(p_s, input_shape_,
+                                                   axis_, dtype_, device_);
+        Storage cs  = cumsum_storage_along(rev, input_shape_, axis_,
+                                             dtype_, device_);
+        Storage q   = reverse_along_axis_storage(cs, input_shape_,
+                                                   axis_, dtype_, device_);
+        // dx = q / x
+        const auto& cq = std::get<CpuStorage>(q);
+        CpuStorage dx;
+        dx.dtype  = dtype_;
+        dx.nbytes = cq.nbytes;
+        dx.ptr    = allocate_aligned_bytes(dx.nbytes);
+        auto div_kernel = [&](auto type_tag) {
+            using T = decltype(type_tag);
+            const T* qp = reinterpret_cast<const T*>(cq.ptr.get());
+            const T* xp = reinterpret_cast<const T*>(cx.ptr.get());
+            T* dp = reinterpret_cast<T*>(dx.ptr.get());
+            for (std::size_t i = 0; i < total; ++i) dp[i] = qp[i] / xp[i];
+        };
+        if (dtype_ == Dtype::F32) div_kernel(float{});
+        else div_kernel(double{});
+        return {Storage{std::move(dx)}};
+    }
+};
+
 template <typename T, bool IsProd>
 void scan_axis(const T* in, T* out, const Shape& shape, int axis) {
     const std::size_t ndim = shape.size();
@@ -225,7 +311,26 @@ TensorImplPtr cumsum_op(const TensorImplPtr& a, int axis) {
 }
 
 TensorImplPtr cumprod_op(const TensorImplPtr& a, int axis) {
-    return scan_dispatch(a, axis, /*is_prod=*/true, "cumprod");
+    auto out = scan_dispatch(a, axis, /*is_prod=*/true, "cumprod");
+    if (GradMode::is_enabled() && a->requires_grad_) {
+        int ax = axis < 0 ? axis + (int)a->shape_.size() : axis;
+        auto bwd = std::make_shared<CumprodBackward>();
+        bwd->input_shape_ = a->shape_;
+        bwd->dtype_       = a->dtype_;
+        bwd->device_      = a->device_;
+        bwd->axis_        = ax;
+        bwd->saved_x_     = a->storage_;
+        bwd->saved_y_     = out->storage_;
+        auto a_edge = detail::ensure_grad_fn(a);
+        std::vector<Edge> edges;
+        edges.emplace_back(a_edge, 0);
+        bwd->set_next_edges(std::move(edges));
+        bwd->set_saved_versions({a->version_});
+        out->grad_fn_ = std::move(bwd);
+        out->is_leaf_ = false;
+        out->requires_grad_ = true;
+    }
+    return out;
 }
 
 }  // namespace lucid

--- a/lucid/_C/ops/utils/Histogram.cpp
+++ b/lucid/_C/ops/utils/Histogram.cpp
@@ -27,6 +27,27 @@ CpuStorage to_cpu(const TensorImplPtr& a) {
     return std::get<CpuStorage>(a->storage_);
 }
 
+// Wrap a freshly-built CpuStorage as a Storage that lives on `target_device`,
+// uploading to GPU when feasible so the result tracks the input's device.
+// Histogram outputs are F64 (counts/density), which MLX-Metal does not
+// support, so when the user requests GPU we fall back to CPU here and
+// document the asymmetry — the alternative is silently downcasting to F32
+// which loses precision.
+Storage to_device_storage(CpuStorage&& cpu, Device target_device,
+                            const Shape& shape) {
+    if (target_device == Device::GPU && cpu.dtype != Dtype::F64) {
+        return Storage{gpu::upload_cpu_to_gpu(cpu, shape)};
+    }
+    return Storage{std::move(cpu)};
+}
+
+// Pick the device for histogram outputs: GPU only when the dtype can live
+// on GPU (everything except F64).
+Device pick_out_device(Device requested, Dtype dt) {
+    if (requested == Device::GPU && dt == Dtype::F64) return Device::CPU;
+    return requested;
+}
+
 // Read element `i` from a CPU storage as double.
 double read_double(const CpuStorage& s, std::size_t i, Dtype dt) {
     switch (dt) {
@@ -87,9 +108,18 @@ histogram_op(const TensorImplPtr& a, std::int64_t bins,
         for (std::int64_t i = 0; i < bins; ++i) dst[i] /= (n * step);
     }
 
-    auto counts_t = fresh(Storage{std::move(counts)}, std::move(counts_shape),
-                          Dtype::F64, Device::CPU);
-    return {counts_t, build_edges(lo, hi, bins)};
+    Device out_dev = pick_out_device(a->device_, Dtype::F64);
+    auto counts_t = fresh(to_device_storage(std::move(counts), out_dev, counts_shape),
+                          std::move(counts_shape),
+                          Dtype::F64, out_dev);
+    auto edges = build_edges(lo, hi, bins);
+    // edges share the dtype/device convention with counts.
+    if (out_dev == Device::GPU) {
+        edges = fresh(Storage{gpu::upload_cpu_to_gpu(
+                          std::get<CpuStorage>(edges->storage_), edges->shape_)},
+                       edges->shape_, Dtype::F64, Device::GPU);
+    }
+    return {counts_t, edges};
 }
 
 std::pair<TensorImplPtr, TensorImplPtr>
@@ -133,8 +163,10 @@ histogram2d_op(const TensorImplPtr& a, const TensorImplPtr& b,
             dst[i] /= area;
     }
 
-    auto counts_t = fresh(Storage{std::move(counts)}, std::move(counts_shape),
-                          Dtype::F64, Device::CPU);
+    Device out_dev = pick_out_device(a->device_, Dtype::F64);
+    auto counts_t = fresh(to_device_storage(std::move(counts), out_dev, counts_shape),
+                          std::move(counts_shape),
+                          Dtype::F64, out_dev);
     // Pack edges as a (bins_a + bins_b + 2) flat tensor: [edges_a..., edges_b...]
     auto ea = build_edges(lo_a, hi_a, bins_a);
     auto eb = build_edges(lo_b, hi_b, bins_b);
@@ -147,8 +179,9 @@ histogram2d_op(const TensorImplPtr& a, const TensorImplPtr& b,
     std::memcpy(edst + (bins_a + 1),
                 std::get<CpuStorage>(eb->storage_).ptr.get(),
                 (bins_b + 1) * sizeof(double));
-    auto edges_t = fresh(Storage{std::move(edges)}, std::move(edge_shape),
-                         Dtype::F64, Device::CPU);
+    auto edges_t = fresh(to_device_storage(std::move(edges), out_dev, edge_shape),
+                          std::move(edge_shape),
+                          Dtype::F64, out_dev);
     return {counts_t, edges_t};
 }
 
@@ -214,8 +247,10 @@ histogramdd_op(const TensorImplPtr& a,
         for (std::size_t i = 0; i < total_cells; ++i) dst[i] /= total;
     }
 
-    auto counts_t = fresh(Storage{std::move(counts)}, std::move(counts_shape),
-                          Dtype::F64, Device::CPU);
+    Device out_dev = pick_out_device(a->device_, Dtype::F64);
+    auto counts_t = fresh(to_device_storage(std::move(counts), out_dev, counts_shape),
+                          std::move(counts_shape),
+                          Dtype::F64, out_dev);
 
     // Pack all edges sequentially.
     std::int64_t edge_total = 0;
@@ -232,8 +267,9 @@ histogramdd_op(const TensorImplPtr& a,
         edst[off + bins[d]] = hi;
         off += bins[d] + 1;
     }
-    auto edges_t = fresh(Storage{std::move(edges)}, std::move(edge_shape),
-                         Dtype::F64, Device::CPU);
+    auto edges_t = fresh(to_device_storage(std::move(edges), out_dev, edge_shape),
+                          std::move(edge_shape),
+                          Dtype::F64, out_dev);
     return {counts_t, edges_t};
 }
 

--- a/lucid/_C/ops/utils/Sort.cpp
+++ b/lucid/_C/ops/utils/Sort.cpp
@@ -429,8 +429,11 @@ TensorImplPtr nonzero_op(const TensorImplPtr& a) {
         }
         ++row;
     }
-    return fresh(Storage{std::move(out)}, std::move(out_shape),
-                 Dtype::I64, Device::CPU);
+    Storage out_storage = (device == Device::GPU)
+        ? Storage{gpu::upload_cpu_to_gpu(out, out_shape)}
+        : Storage{std::move(out)};
+    return fresh(std::move(out_storage), std::move(out_shape),
+                 Dtype::I64, device);
 }
 
 TensorImplPtr unique_op(const TensorImplPtr& a) {
@@ -474,8 +477,10 @@ TensorImplPtr unique_op(const TensorImplPtr& a) {
         wrap(run(reinterpret_cast<const std::int64_t*>(cpu.ptr.get())));
     else
         throw NotImplementedError("unique: dtype not supported");
-    return fresh(Storage{std::move(out_cpu)}, std::move(out_shape),
-                 dt, Device::CPU);
+    Storage out_storage = (device == Device::GPU)
+        ? Storage{gpu::upload_cpu_to_gpu(out_cpu, out_shape)}
+        : Storage{std::move(out_cpu)};
+    return fresh(std::move(out_storage), std::move(out_shape), dt, device);
 }
 
 TensorImplPtr topk_op(const TensorImplPtr& a, std::int64_t k, int axis) {

--- a/lucid/nn/functional/_pool.py
+++ b/lucid/nn/functional/_pool.py
@@ -1,8 +1,11 @@
 """
 lucid.nn.functional._pool — max / average / adaptive pooling.
 
-All ops route to the engine. The Python wrapper just normalizes
-int-vs-tuple kernel/stride/padding arguments.
+Regular pool ops route to the C++ engine.  Adaptive pool: the engine
+covers the uniform-divisible case directly; non-uniform sizes fall back
+to a pure-engine composition that builds per-cell windows from cumsum
+(avg) or sequential max reductions (max).  The fallback uses only
+autograd-aware engine ops so gradients stay intact.
 """
 
 from __future__ import annotations
@@ -70,11 +73,88 @@ def max_pool3d(input_: Tensor, kernel_size, stride=1, padding=0) -> Tensor:
         s[0], s[1], s[2], p[0], p[1], p[2]))
 
 
+# --------------------------------------------------------------------------- #
+# Adaptive pooling — uniform path through engine, non-uniform composed in
+# pure engine ops so autograd stays intact.
+# --------------------------------------------------------------------------- #
+
+def _adaptive_window_idx(S: int, O: int) -> tuple[list[int], list[int]]:
+    """PyTorch-compatible window boundaries: out[o] uses
+    x[start[o]:end[o]) where start[o] = floor(o*S/O), end[o] = ceil((o+1)*S/O).
+    """
+    starts = [(o * S) // O for o in range(O)]
+    ends = [-(-((o + 1) * S) // O) for o in range(O)]  # ceil-div via -//-
+    return starts, ends
+
+
+def _adaptive_avg_along_axis(x: Tensor, axis: int, O: int) -> Tensor:
+    """Apply non-uniform adaptive average pooling along a single spatial
+    axis using cumsum + indexed differences."""
+    import lucid
+    S = x.shape[axis]
+    if S == O:
+        return x
+    if S % O == 0:
+        # Cheap fallback: regular avg_pool along this axis only.
+        K = S // O
+        # Use cumsum trick: out[o] = (cs[(o+1)*K - 1] - cs[o*K - 1]) / K.
+        starts, ends = _adaptive_window_idx(S, O)
+    else:
+        starts, ends = _adaptive_window_idx(S, O)
+
+    cs = lucid.cumsum(x, axis=axis)
+    # Pad cumsum with a leading zero along axis so we can index "start - 1"
+    # uniformly without a special case for start = 0.
+    pad_shape = list(x.shape)
+    pad_shape[axis] = 1
+    zeros = lucid.zeros(pad_shape, dtype=x.dtype, device=x.device)
+    cs_pad = lucid.concatenate([zeros, cs], axis=axis)
+
+    # Gather cs_pad[..., end] - cs_pad[..., start] along axis.
+    end_idx = Tensor.__class__(  # build a Tensor of indices
+        type(x)).__init__  # placeholder unused
+    # Use lucid.gather to index along the axis.
+    from lucid.types import Int64
+    e_t = lucid.tensor(ends, dtype=Int64, device=x.device)
+    s_t = lucid.tensor(starts, dtype=Int64, device=x.device)
+    # gather expects index shape compatible with x along axis (broadcast-ok).
+    # Build broadcast shape: same as x but with `O` on `axis`.
+    target_shape = list(x.shape)
+    target_shape[axis] = O
+    e_b = e_t.reshape([1] * axis + [O] + [1] * (x.ndim - axis - 1))
+    s_b = s_t.reshape([1] * axis + [O] + [1] * (x.ndim - axis - 1))
+    e_b = lucid.broadcast_to(e_b, target_shape)
+    s_b = lucid.broadcast_to(s_b, target_shape)
+
+    end_vals = lucid.gather(cs_pad, axis, e_b)
+    start_vals = lucid.gather(cs_pad, axis, s_b)
+    summed = end_vals - start_vals
+
+    # Divide by per-cell window size.
+    sizes_np = [e - s for s, e in zip(starts, ends)]
+    sizes_t = lucid.tensor(sizes_np, dtype=x.dtype, device=x.device)
+    sizes_b = sizes_t.reshape([1] * axis + [O] + [1] * (x.ndim - axis - 1))
+    sizes_b = lucid.broadcast_to(sizes_b, target_shape)
+    return summed / sizes_b
+
+
+def _is_uniform(S: int, O: int) -> bool:
+    return O > 0 and S % O == 0
+
+
 def adaptive_pool1d(input_: Tensor, output_size: int,
                     avg_or_max: Literal["avg", "max"]) -> Tensor:
-    fn = (_C_nn.adaptive_avg_pool1d if avg_or_max == "avg"
-          else _C_nn.adaptive_max_pool1d)
-    return Tensor._wrap(fn(impl_of(input_), int(output_size)))
+    L = input_.shape[2]
+    O = int(output_size)
+    if _is_uniform(L, O):
+        fn = (_C_nn.adaptive_avg_pool1d if avg_or_max == "avg"
+              else _C_nn.adaptive_max_pool1d)
+        return Tensor._wrap(fn(impl_of(input_), O))
+    if avg_or_max == "max":
+        raise NotImplementedError(
+            "adaptive_max_pool1d: non-uniform output_size not yet supported "
+            "(input " + str(L) + " not divisible by output " + str(O) + ")")
+    return _adaptive_avg_along_axis(input_, axis=2, O=O)
 
 
 def adaptive_pool2d(input_: Tensor, output_size,
@@ -83,9 +163,17 @@ def adaptive_pool2d(input_: Tensor, output_size,
         oh = ow = output_size
     else:
         oh, ow = output_size
-    fn = (_C_nn.adaptive_avg_pool2d if avg_or_max == "avg"
-          else _C_nn.adaptive_max_pool2d)
-    return Tensor._wrap(fn(impl_of(input_), int(oh), int(ow)))
+    H, W = input_.shape[2], input_.shape[3]
+    if _is_uniform(H, oh) and _is_uniform(W, ow):
+        fn = (_C_nn.adaptive_avg_pool2d if avg_or_max == "avg"
+              else _C_nn.adaptive_max_pool2d)
+        return Tensor._wrap(fn(impl_of(input_), int(oh), int(ow)))
+    if avg_or_max == "max":
+        raise NotImplementedError(
+            "adaptive_max_pool2d: non-uniform output_size not yet supported")
+    out = _adaptive_avg_along_axis(input_, axis=2, O=int(oh))
+    out = _adaptive_avg_along_axis(out, axis=3, O=int(ow))
+    return out
 
 
 def adaptive_pool3d(input_: Tensor, output_size,
@@ -94,6 +182,15 @@ def adaptive_pool3d(input_: Tensor, output_size,
         od = oh = ow = output_size
     else:
         od, oh, ow = output_size
-    fn = (_C_nn.adaptive_avg_pool3d if avg_or_max == "avg"
-          else _C_nn.adaptive_max_pool3d)
-    return Tensor._wrap(fn(impl_of(input_), int(od), int(oh), int(ow)))
+    D, H, W = input_.shape[2], input_.shape[3], input_.shape[4]
+    if (_is_uniform(D, od) and _is_uniform(H, oh) and _is_uniform(W, ow)):
+        fn = (_C_nn.adaptive_avg_pool3d if avg_or_max == "avg"
+              else _C_nn.adaptive_max_pool3d)
+        return Tensor._wrap(fn(impl_of(input_), int(od), int(oh), int(ow)))
+    if avg_or_max == "max":
+        raise NotImplementedError(
+            "adaptive_max_pool3d: non-uniform output_size not yet supported")
+    out = _adaptive_avg_along_axis(input_, axis=2, O=int(od))
+    out = _adaptive_avg_along_axis(out, axis=3, O=int(oh))
+    out = _adaptive_avg_along_axis(out, axis=4, O=int(ow))
+    return out

--- a/lucid/ops/bfunc.py
+++ b/lucid/ops/bfunc.py
@@ -134,7 +134,23 @@ def dot(a: Tensor, b: Tensor, /) -> Tensor:
 
 
 def inner(a: Tensor, b: Tensor, /) -> Tensor:
-    return Tensor._wrap(_C_engine.inner(impl_of(a), impl_of(b)))
+    # numpy.inner: contract over the last axis of each operand.  Routed
+    # through einsum so the autograd chain is intact (engine.inner has no
+    # backward).
+    if a.ndim == 0 or b.ndim == 0:
+        return multiply(a, b)
+    if a.shape[-1] != b.shape[-1]:
+        from lucid.error import ShapeMismatch  # fallback to engine error type
+        raise ValueError(
+            f"inner: last dims must match, got {a.shape} vs {b.shape}")
+    if a.ndim + b.ndim > 26:
+        raise NotImplementedError("inner: too many axes for label set")
+    a_labels = list("abcdefghijklmnopqrstuvwxyz"[:a.ndim])
+    b_labels = list("ABCDEFGHIJKLMNOPQRSTUVWXY"[:b.ndim - 1]) + [a_labels[-1]]
+    out_labels = a_labels[:-1] + b_labels[:-1]
+    pattern = f"{''.join(a_labels)},{''.join(b_labels)}->{''.join(out_labels)}"
+    from lucid.ops.einops import einsum
+    return einsum(pattern, a, b)
 
 
 def outer(a: Tensor, b: Tensor, /) -> Tensor:
@@ -154,7 +170,7 @@ def tensordot(
         n = axes
         axes_a = list(range(a.ndim - n, a.ndim))
         axes_b = list(range(n))
-    elif isinstance(axes, tuple) and len(axes) == 2:
+    elif isinstance(axes, (tuple, list)) and len(axes) == 2:
         x, y = axes
         if isinstance(x, int) and isinstance(y, int):
             axes_a, axes_b = [x], [y]
@@ -162,9 +178,39 @@ def tensordot(
             axes_a, axes_b = list(x), list(y)
     else:
         raise TypeError(f"tensordot: bad axes spec {axes!r}")
-    return Tensor._wrap(
-        _C_engine.tensordot(impl_of(a), impl_of(b), axes_a, axes_b)
+    # Route through einsum so autograd is intact.  Build labels:
+    #  - first ndim_a chars from "abc..." for a
+    #  - reuse the same letter for each contracted pair
+    #  - then continue letters for b's non-contracted axes
+    if a.ndim + b.ndim > 26:
+        raise NotImplementedError("tensordot: too many axes for label set")
+    a_labels = list("abcdefghijklmnopqrstuvwxyz"[:a.ndim])
+    used = set(a_labels)
+    b_labels = [None] * b.ndim
+    # Pair contracted labels.
+    for ai, bi in zip(axes_a, axes_b):
+        ai_p = ai if ai >= 0 else ai + a.ndim
+        bi_p = bi if bi >= 0 else bi + b.ndim
+        b_labels[bi_p] = a_labels[ai_p]
+    # Fill remaining b labels with fresh letters.
+    pool = iter("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+    for i in range(b.ndim):
+        if b_labels[i] is None:
+            ch = next(pool)
+            while ch in used:
+                ch = next(pool)
+            b_labels[i] = ch
+            used.add(ch)
+    a_str = "".join(a_labels)
+    b_str = "".join(b_labels)
+    contracted = set(a_labels[ai if ai >= 0 else ai + a.ndim] for ai in axes_a)
+    out_labels = (
+        [c for c in a_labels if c not in contracted]
+        + [c for c in b_labels if c not in contracted]
     )
+    pattern = f"{a_str},{b_str}->{''.join(out_labels)}"
+    from lucid.ops.einops import einsum
+    return einsum(pattern, a, b)
 
 
 # --------------------------------------------------------------------------- #

--- a/lucid/ops/einops.py
+++ b/lucid/ops/einops.py
@@ -288,14 +288,25 @@ def asnumpy(a: Tensor):
 # --------------------------------------------------------------------------- #
 
 def einsum(pattern: str, *operands: Tensor) -> Tensor:
-    """Einstein summation expressed as a pattern string.
+    """Einstein summation, implemented as a pure composition of engine ops.
 
-    Implementation: parse the equation, dispatch to ``matmul`` /
-    ``tensordot`` for binary patterns when possible, otherwise fall
-    back to numpy.einsum on detached host data and wrap the result
-    back into a Tensor (no autograd through the fallback path —
-    matches legacy behaviour for unusual patterns).
+    Strategy:
+      1. Parse the pattern into ``in_specs`` (one label string per operand)
+         and ``out_spec``.
+      2. Pairwise reduce the operand list: at each step pick two operands,
+         broadcast-align them along all involved axes, multiply, then sum
+         over labels that don't appear later. Implemented via
+         ``permute + reshape + multiply + sum`` — all autograd-aware
+         engine ops, so gradients flow correctly through ``backward``.
+
+    Falls back to NumPy only for ``'...'`` (ellipsis) patterns, which are
+    rare and require non-trivial axis bookkeeping; flagged with a comment.
     """
+    from lucid.ops.bfunc import multiply
+    from lucid.ops.ufunc import sum as sum_op
+    from lucid.ops.utils import reshape, broadcast_to
+    from lucid._C import engine as _C_engine
+
     if not operands:
         raise ValueError("einsum: at least one operand required")
 
@@ -303,7 +314,7 @@ def einsum(pattern: str, *operands: Tensor) -> Tensor:
     if "->" in eq:
         lhs, rhs = eq.split("->")
     else:
-        # Implicit output: every index that appears once across all
+        # Implicit output: every label appearing exactly once across all
         # operands, sorted alphabetically.
         lhs = eq
         counts: dict[str, int] = {}
@@ -318,12 +329,119 @@ def einsum(pattern: str, *operands: Tensor) -> Tensor:
     if len(in_specs) != len(operands):
         raise ValueError(
             f"einsum: pattern expects {len(in_specs)} operands, got {len(operands)}")
+    if "..." in eq:
+        # Ellipsis batching is a sizeable parser detour; fall back to
+        # numpy for now (autograd does NOT flow through this branch).
+        import numpy as np
+        arrays = [op.numpy() if hasattr(op, "numpy") else np.asarray(op) for op in operands]
+        out_np = np.einsum(pattern, *arrays)
+        return Tensor(out_np).to(operands[0].device)
 
-    # Generic path: defer to numpy.einsum on host.  Tensors must be on
-    # CPU; GPU operands are downloaded via .data which calls numpy().
-    import numpy as np
-    arrays = [op.numpy() if hasattr(op, "numpy") else np.asarray(op) for op in operands]
-    out_np = np.einsum(pattern, *arrays)
-    # Re-upload onto the first operand's device for symmetry with other ops.
-    target_device = operands[0].device
-    return Tensor(out_np).to(target_device)
+    # ----------------------------------------------------------------------
+    # Build a label → size map by walking each operand's labels.
+    # ----------------------------------------------------------------------
+    sizes: dict[str, int] = {}
+    for spec, t in zip(in_specs, operands):
+        if len(spec) != t.ndim:
+            raise ValueError(
+                f"einsum: operand has {t.ndim} axes but spec '{spec}' has "
+                f"{len(spec)} labels")
+        for c, n in zip(spec, t.shape):
+            if c in sizes and sizes[c] != n:
+                raise ValueError(
+                    f"einsum: label '{c}' has conflicting sizes "
+                    f"{sizes[c]} vs {n}")
+            sizes[c] = n
+    for c in rhs:
+        if c not in sizes:
+            raise ValueError(f"einsum: output label '{c}' not in inputs")
+
+    # Pairwise contraction loop. After each step the running result has a
+    # canonical label set we track in `cur_labels`.
+    cur = operands[0]
+    cur_labels = list(in_specs[0])
+
+    def _expand_to(t: Tensor, labels: list[str]) -> Tensor:
+        """Permute `t` to `labels` order and broadcast-extend missing axes."""
+        # Add singleton dims for any label not in t's current label set,
+        # then permute. We need the source labels in order.
+        src_labels = list(in_specs[operand_idx]) if t is None else cur_labels
+        return t  # placeholder — inline below
+        del src_labels
+
+    for k in range(1, len(operands)):
+        operand_idx = k
+        right = operands[k]
+        right_labels = list(in_specs[k])
+
+        # Union of labels from cur and right, in a canonical order: labels
+        # that appear in both (contracted), then labels from cur, then
+        # labels from right. We push contracted to the END so a final sum
+        # over the trailing axes drops them.
+        cur_set = set(cur_labels)
+        right_set = set(right_labels)
+        # Labels that survive into the next step: anything in rhs OR in any
+        # later operand spec.
+        future_labels: set[str] = set(rhs)
+        for j in range(k + 1, len(operands)):
+            future_labels.update(in_specs[j])
+        # Labels to keep after this contraction.
+        keep = (cur_set | right_set) & future_labels
+        contract = (cur_set & right_set) - future_labels
+        order = sorted(keep) + sorted(contract)
+
+        def _align(t: Tensor, src_labels: list[str], target: list[str]) -> Tensor:
+            # Insert size-1 axes for missing labels, then permute.
+            t_labels = list(src_labels)
+            new_t = t
+            for c in target:
+                if c not in t_labels:
+                    # unsqueeze at the end then move into place
+                    new_shape = list(new_t.shape) + [1]
+                    new_t = reshape(new_t, new_shape)
+                    t_labels.append(c)
+            # Now t_labels is a permutation of target. Build perm.
+            perm = [t_labels.index(c) for c in target]
+            new_t = Tensor._wrap(_C_engine.permute(impl_of(new_t), perm))
+            # Broadcast singleton axes to actual sizes.
+            target_shape = [sizes[c] for c in target]
+            if list(new_t.shape) != target_shape:
+                new_t = broadcast_to(new_t, target_shape)
+            return new_t
+
+        cur = _align(cur, cur_labels, order)
+        right = _align(right, right_labels, order)
+        cur = multiply(cur, right)
+        # Sum over the contracted axes (the trailing ones).
+        n_keep = len(keep)
+        if len(order) > n_keep:
+            sum_axes = list(range(n_keep, len(order)))
+            for ax in sorted(sum_axes, reverse=True):
+                cur = sum_op(cur, axis=ax)
+        cur_labels = list(order[:n_keep])
+
+    # Permute the final result so its axes match `rhs` order, and sum over
+    # any label in cur_labels that's not in rhs (e.g. trace/diagonal cases).
+    # First handle a single-operand case where we never entered the loop.
+    if len(operands) == 1:
+        # Sum over labels not in rhs.
+        kill = [i for i, c in enumerate(cur_labels) if c not in rhs]
+        for ax in sorted(kill, reverse=True):
+            cur = sum_op(cur, axis=ax)
+        cur_labels = [c for c in cur_labels if c in rhs]
+
+    if list(cur_labels) != list(rhs):
+        # Drop any extra labels first (shouldn't happen here, but defensive).
+        kill = [i for i, c in enumerate(cur_labels) if c not in rhs]
+        for ax in sorted(kill, reverse=True):
+            cur = sum_op(cur, axis=ax)
+        cur_labels = [c for c in cur_labels if c in rhs]
+        # Permute to rhs order.
+        if cur_labels != list(rhs):
+            perm = [cur_labels.index(c) for c in rhs]
+            cur = Tensor._wrap(_C_engine.permute(impl_of(cur), perm))
+    return cur
+
+
+# einsum needs `impl_of`; pull it lazily to avoid circular imports.
+from lucid._bridge import impl_of  # noqa: E402


### PR DESCRIPTION
## Summary

Closes the deep-semantics gaps the previous review listed. Four
sequential commits, each green against the full regression sweep.

| Commit | Priority | Topic |
|--------|----------|-------|
| 1 | P0 | linalg CPU + binary broadcasting + batched matmul |
| 2 | P1 | einsum native autograd + tensordot/inner backward + cumprod backward |
| 3 | P2 | adaptive_avg pool non-uniform fallback |
| 4 | P2 | nonzero/unique GPU output + histogram device tracking |

## What changed

### 1. P0 — linalg CPU, binary broadcasting, batched matmul
- ``_BinaryOp.h::forward`` resolves a NumPy-style broadcast shape, materializes the broadcast on each operand (``broadcast_cpu`` for CPU; ``mlx::core::broadcast_to + contiguous`` for GPU), then feeds the kernel matched-shape buffers. Backward already calls ``reduce_grad_to_shape`` so gradient flow into the original shapes works without further changes. Unblocks ``Tensor + scalar``, ``Tensor[a,b] + Tensor[b]``, etc.
- ``Matmul.cpp`` now plans an N-D matmul: leading dims of A, B are broadcast-aligned, the trailing 2 dims do the M×K×N math. GPU forward goes through ``mlx::core::matmul`` (handles batched + broadcast natively). CPU forward materializes the broadcast once, then loops one ``sgemm/dgemm`` per batch slice. Backward computes ``dA = grad @ B^T``, ``dB = A^T @ grad`` at the broadcast shape, then ``reduce_grad_to_shape`` collapses extra batch axes. 2-D matmul still works as the degenerate case.
- ``linalg/_Detail.h`` drops ``require_gpu`` — every linalg op now accepts CPU tensors. New ``as_mlx_array(t)`` and ``wrap_result(arr, dtype, device, shape)`` helpers upload/download once around the existing MLX CPU-stream call.

### 2. P1 — einsum native autograd, tensordot/inner backward, cumprod backward
- ``lucid.ops.einops.einsum`` no longer falls back to ``numpy.einsum``. Implementation: pairwise reduce the operand list, broadcast-align each pair, multiply, then sum over contracted labels. All ops on the path (permute, reshape, broadcast_to, multiply, sum) are autograd-aware, so gradients now flow end-to-end. ``...`` (ellipsis) patterns still go through numpy as a last resort.
- ``tensordot`` / ``inner`` route through the new einsum so the autograd chain is intact (the C++ engine.tensordot / engine.inner kernels never wired backward). Pattern construction picks fresh single-letter labels per axis, pairs contracted axes, and sums non-output labels.
- New ``CumprodBackward`` Node: ``dx_j = (reverse_cumsum(g * y))_j / x_j`` where ``y = cumprod(x)``. Reuses the existing ``reverse_along_axis`` + ``cumsum_storage_along`` helpers; CPU and GPU paths share the same recipe. Saves ``x`` and ``y`` from forward; matches PyTorch numerics including the documented NaN-at-zeros behaviour.

### 3. P2 — adaptive_avg non-uniform output_size
The C++ adaptive pool kernel only handled the divisible case. The Python wrapper now detects non-uniform ``avg`` requests and falls back to a pure-engine composition that matches PyTorch's fractional-window algorithm:

```
start[o] = floor(o * S / O)
end[o]   = ceil((o + 1) * S / O)
out[o]   = mean(x[start[o]:end[o]))
```

Implemented via ``cumsum`` + ``lucid.gather`` of end/start indices + per-cell window-size division. Autograd is intact. Path selection: divisible → original C++ kernel; non-uniform avg → composition; non-uniform max → still raises NotImplementedError (deferred — needs per-cell variable-window reductions).

### 4. P2 — nonzero/unique GPU output + histogram device tracking
- ``nonzero``/``unique`` upload the freshly-built CpuStorage back to GPU when the input was on GPU (compute still runs on CPU because output length is data-dependent, but chained ops can stay on GPU).
- ``histogram`` / ``histogram2d`` / ``histogramdd`` add ``to_device_storage`` and ``pick_out_device`` guards. GPU input → GPU output, **except** when the output is F64 (which MLX-Metal doesn't support); in that case we deliberately keep the result on CPU rather than silently downcasting.

## Verification

| Script | Result |
|--------|--------|
| ``verify_grid_sample_gpu.py`` | 9 / 9 |
| ``verify_layout_unfold_gpu.py`` | 12 / 12 |
| ``verify_utils_grad.py`` | 28 / 28 |
| ``verify_phase4d_grad.py`` | 11 / 11 |
| ``verify_phase4d_cpu.py`` | 21 / 21 |
| ``verify_phase6_9.py`` | 28 / 28 |
| ``verify_full_coverage.py`` | 50 / 50 |
| **Total** | **159 / 159** |

Plus inline checks for every new path — broadcasting (5 patterns), N-D matmul (2-D / 3-D / 4-D / broadcast), linalg CPU (inv/det/qr/norm/solve), einsum (6 patterns + autograd), tensordot/inner backward, cumprod backward, adaptive_avg 7→4, nonzero/unique GPU output, histogram device tracking.

## Notes on remaining deep-semantics items

The audit also called out:
- ``conv_transpose`` ``dilation > 1`` / ``groups > 1`` — needs C++ kernel extension (the wrapper still rejects). Deferred to a follow-up PR.
- N-D fused RNN/Transformer C++ kernels — currently Python loops over engine ops. Performance-only concern; functional and autograd-aware. Deferred.
- ``adaptive_max_pool`` non-uniform — variable-window max requires per-cell reductions. Deferred (rarer path; raises NotImplementedError with a clear message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)