### PR TITLE
perf(compile): stateful-variables fused_step path (LUCID_COMPILE_VARS=1)

### DIFF
--- a/lucid/_C/compile/CompiledExecutable.mm
+++ b/lucid/_C/compile/CompiledExecutable.mm
@@ -33,6 +33,19 @@ class CompiledExecutable {
 public:
     MPSGraphExecutable* executable = nil;  // ARC strong
 
+    // When the executable was compiled from a graph that contains
+    // ``MPSGraphVariable``-backed tensors (``variableWithData:`` /
+    // ``assignVariable:``), the variable's internal storage belongs to
+    // the source MPSGraph object, not to the executable.  Releasing the
+    // graph (e.g. at the end of the compile autoreleasepool) frees the
+    // variable's buffer; subsequent ``runWithMTLCommandQueue:`` calls
+    // then crash inside ``GPU::VarHandleOpHandler::encodeOp`` when the
+    // executor tries to dereference the dangling variable handle.  We
+    // retain the source graph here for variable-bearing compiles so the
+    // variable storage stays live for the executable's lifetime.  For
+    // pure-forward / placeholder-only compiles this field is nil.
+    void* source_graph = nullptr;  // __bridge_retained MPSGraph*
+
     // Trace ids for inputs (feed order) and outputs (target order).
     std::vector<TensorId> input_ids;
     std::vector<TensorId> output_ids;
@@ -66,6 +79,19 @@ public:
     // declared parameters and therefore keep their static shape even
     // in dynamic-batch mode.
     std::unordered_set<std::size_t> static_feed_slots;
+
+    ~CompiledExecutable() {
+        // Release the variable-storage-owning MPSGraph if we retained
+        // one during compile (``compile_generic_fused_step_with_vars``).
+        // ARC handles ``executable``.
+        if (source_graph != nullptr) {
+            @autoreleasepool {
+                MPSGraph* g = (__bridge_transfer MPSGraph*)source_graph;
+                (void)g;
+            }
+            source_graph = nullptr;
+        }
+    }
 };
 
 std::size_t executable_num_inputs(const CompiledExecutable* exe) {

--- a/lucid/_C/compile/MpsBuilder.mm
+++ b/lucid/_C/compile/MpsBuilder.mm
@@ -90,6 +90,11 @@ namespace lucid::compile {
 class CompiledExecutable {
 public:
     MPSGraphExecutable* executable = nil;  // ARC strong (matches .mm)
+    // Phase 1.9: retained source MPSGraph for variable-bearing
+    // executables — keeps the variable storage live for the executable's
+    // lifetime.  See the matching field in CompiledExecutable.mm for
+    // rationale.  nullptr for non-variable compiles (the common case).
+    void* source_graph = nullptr;  // __bridge_retained MPSGraph*
     std::vector<TensorId> input_ids;
     std::vector<TensorId> output_ids;
     std::vector<Shape> input_shapes;
@@ -100,6 +105,20 @@ public:
     std::vector<TensorId> grad_output_ids;  // Phase 1.3
     bool dynamic_batch = false;             // Phase 1.6
     std::unordered_set<std::size_t> static_feed_slots;  // Phase 1.6
+
+    ~CompiledExecutable() {
+        // Mirror the destructor in CompiledExecutable.mm — release the
+        // retained source MPSGraph (if any).  Defined inline here so the
+        // C++ destructor calls the right release; ARC handles
+        // ``executable``.
+        if (source_graph != nullptr) {
+            @autoreleasepool {
+                MPSGraph* g = (__bridge_transfer MPSGraph*)source_graph;
+                (void)g;
+            }
+            source_graph = nullptr;
+        }
+    }
 };
 
 }  // namespace lucid::compile
@@ -1903,6 +1922,14 @@ CompiledExecutable* compile_generic_fused_step_with_vars(
 
         auto* exe = new CompiledExecutable();
         exe->executable = compiled;
+        // Retain the source MPSGraph so its variable storage outlives
+        // the compile autoreleasepool.  Without this, MPSGraph releases
+        // the variable's backing MTLBuffer along with the graph object;
+        // subsequent ``runWithMTLCommandQueue:`` calls segfault inside
+        // ``GPU::VarHandleOpHandler::encodeOp`` when the executor tries
+        // to dereference the dangling variable handle.  The retain is
+        // released in ``~CompiledExecutable``.
+        exe->source_graph = (__bridge_retained void*)graph_obj;
         exe->input_ids = std::move(ordered_feed_ids);
         exe->output_ids = std::vector<TensorId>{loss_id};
         exe->grad_output_ids = std::move(aux_output_ids);

--- a/lucid/__init__.py
+++ b/lucid/__init__.py
@@ -19,7 +19,7 @@ try:
             f"lucid C++ engine ABI mismatch: expected {_EXPECTED_ABI}, "
             f"got {_abi}. Rebuild the engine."
         )
-except TypeError, ValueError:
+except (TypeError, ValueError):
     pass  # Mocked during docs build — skip ABI check
 
 # fmt: off

--- a/lucid/compile/_fused_step.py
+++ b/lucid/compile/_fused_step.py
@@ -415,24 +415,51 @@ class _FusedStep:
             output_target_ids.append(int(tid))
 
         # ``compile_generic_fused_step_with_vars`` (MPSGraph stateful
-        # variables variant) is wired through the C++ binding and
-        # standalone-validated, but full Lucid integration hangs on
-        # first execution.  Both the ``readVariable`` post-assign
-        # output and the ``new_value_t`` direct-output variants
-        # exhibit the same hang.  Root cause is in MPSGraph's
-        # scheduling of (gradientForPrimaryTensor: ⨯ variable ⨯ Lucid
-        # trace ops ⨯ assignVariable) — needs further investigation
-        # or Apple SDK support.  Integration paused; infrastructure
-        # preserved (compile_generic_fused_step_with_vars in
-        # MpsBuilder.mm).
-        exe = _C_engine.compile.compile_generic_fused_step(
-            graph,
-            ext,
-            loss_id,
-            param_ids,
-            ghost_grad_ids,
-            output_target_ids,
-        )
+        # variables variant) is now functional after the source-graph
+        # retention fix in CompiledExecutable.mm — previously the
+        # source ``MPSGraph`` was released at the end of the compile
+        # autoreleasepool, freeing the variable's MTLBuffer and causing
+        # a SIGSEGV inside ``GPU::VarHandleOpHandler::encodeOp`` on the
+        # first ``runWithMTLCommandQueue:`` (manifested as an
+        # indefinite hang because the GPU command buffer never
+        # completed).  Gated behind ``LUCID_COMPILE_VARS=1`` until a
+        # follow-up PR validates performance + memory characteristics
+        # at model-zoo scale; the default path stays on the in/out-feed
+        # ``compile_generic_fused_step`` so the long-run + training
+        # regression matrix continues to exercise the production code.
+        import os as _os
+        _use_vars = _os.environ.get("LUCID_COMPILE_VARS", "0") in ("1", "true", "True")
+        if _use_vars:
+            # Build (feed_id, write_id) pairs: each parameter feed
+            # becomes a variable, paired with the matching opt-output
+            # id (the "new_param" tensor for that parameter).  The
+            # opt-output order matches param_ids order in every
+            # ``_trace_update`` implementation — the first N opt
+            # outputs are the new params, followed by new state
+            # buffers.  Only the param-tier entries get promoted to
+            # variables; momenta / m / v stay as input/output feeds.
+            variable_pairs: list[tuple[int, int]] = []
+            for i, pid in enumerate(param_ids):
+                if i < len(output_target_ids):
+                    variable_pairs.append((pid, output_target_ids[i]))
+            exe = _C_engine.compile.compile_generic_fused_step_with_vars(
+                graph,
+                ext,
+                loss_id,
+                param_ids,
+                ghost_grad_ids,
+                output_target_ids,
+                variable_pairs,
+            )
+        else:
+            exe = _C_engine.compile.compile_generic_fused_step(
+                graph,
+                ext,
+                loss_id,
+                param_ids,
+                ghost_grad_ids,
+                output_target_ids,
+            )
         if exe is None:
             raise RuntimeError(
                 "fused_step: compile_generic_fused_step returned None — "


### PR DESCRIPTION
## Summary

Re-enables the **MPSGraph stateful-variables** fused_step path (wired in Phase 1.9, disabled after first-execution hangs). Gated behind `LUCID_COMPILE_VARS=1` until soak testing validates it at model-zoo scale.

**Root cause of the hang:** dangling variable handle. The source `MPSGraph` owns the variable's backing `MTLBuffer`, but the graph object was being released at the end of the compile autoreleasepool, freeing that buffer. The first `runWithMTLCommandQueue:` would dereference the dangling handle inside `GPU::VarHandleOpHandler::encodeOp` and stall the GPU command buffer indefinitely (no crash, just hang).

**Fix:** retain the source graph as `__bridge_retained void*` on `CompiledExecutable` (mirrored definition in both `CompiledExecutable.mm` and `MpsBuilder.mm`), released in the destructor. The retention is only paid for variable-bearing compiles — `source_graph = nullptr` on the common forward / placeholder path.

## Bench (`tools/bench_compile --quick`, training step)

| Model | vars=0 (fused, ms) | vars=1 (fused, ms) | Speedup |
|---|---:|---:|---:|
| mlp (64→128→10, BS=32) | 1.28 | 0.79 | **1.6×** |
| deep_mlp (×4 hidden, BS=64) | 4.21 | 1.55 | **2.7×** |

The bigger the parameter set, the more wallclock is recovered by *not* having to copy back N parameter tensors per step — they live as MPSGraph variables and are mutated in place.

## Parity

Verified on SGD / Adam / AdamW / RMSprop — final loss within `1e-3` of eager after 100 steps. Residual gap is the semantic difference between pre-update and post-update loss reads (the vars path returns the loss computed against the *previous* parameter state, eager re-evaluates after `opt.step()`), not numerical drift.

## Scope

- `lucid/_C/compile/CompiledExecutable.mm` — add `source_graph` field + destructor
- `lucid/_C/compile/MpsBuilder.mm` — mirror the field/destructor (one-TU pattern), set `source_graph` in `compile_generic_fused_step_with_vars`
- `lucid/compile/_fused_step.py` — `LUCID_COMPILE_VARS=1` opt-in branch + variable_pairs construction
- `lucid/__init__.py` — drive-by fix for invalid Python 3.14 syntax `except TypeError, ValueError:` → parenthesised-tuple form

Default path stays on the validated in/out-feed `compile_generic_fused_step` so the long-run + training regression matrix continues to exercise the production code.

## Test plan

- [x] `pytest lucid/test/unit/compile/` — 58 passed (default path)
- [x] `LUCID_COMPILE_VARS=1 pytest lucid/test/unit/compile/` — 58 passed (variables path doesn't break existing tests)
- [x] Manual: SGD / Adam / AdamW / RMSprop convergence with vars on, 100 steps each, parity vs eager
- [x] `tools/bench_compile --quick --iter 30` both modes — see table above
- [ ] Follow-up: soak test on model-zoo training scripts before flipping default to vars=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)