### PR TITLE
Fix decode_step exception tuple syntax

### DIFF
--- a/lucid/compile/_entry/decode_step.py
+++ b/lucid/compile/_entry/decode_step.py
@@ -307,7 +307,7 @@ def compiled_decode_step(
                 dynamic=False,
                 param_fingerprint=(),
             )
-        except TypeError, AttributeError:
+        except (TypeError, AttributeError):
             key = None
 
         if key is not None and key in eager_sigs:


### PR DESCRIPTION
Fixes #54.

## Summary
- restore the parenthesized exception tuple in `decode_step.py`
- make the module parseable/importable on Python 3.x again

## Tests
- `uv run python -m py_compile lucid/compile/_entry/decode_step.py`
- `uv run python - <<'PY' ... ast.parse(...)`
- `uv run --with ruff ruff check lucid/compile/_entry/decode_step.py`
- `git diff --check`
